### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+cache: cargo
+addons:
+  apt:
+    packages:
+    - libdbus-1-dev


### PR DESCRIPTION
Adds simple build configuration. Can be expanded later when the need arises.