### PR TITLE
Add progress tracking API

### DIFF
--- a/examples/progress_tracker.rs
+++ b/examples/progress_tracker.rs
@@ -55,8 +55,7 @@ fn print_playback_status(progress: &Progress) {
 }
 
 fn main() {
-    let player_finder = PlayerFinder::new().unwrap();
-    let player = player_finder.find_active().unwrap();
+    let player = PlayerFinder::new().unwrap().find_active().unwrap();
     let identity = player.identity();
 
     let mut progress_tracker = player.track_progress(100).unwrap();

--- a/examples/progress_tracker.rs
+++ b/examples/progress_tracker.rs
@@ -69,7 +69,11 @@ fn main() {
         print!(" - ");
         print_title(&progress.metadata);
         print!(" [");
-        print_time(progress.position());
+        if progress.supports_position() {
+            print_time(Some(progress.position()));
+        } else {
+            print_time(None);
+        }
         print!(" / ");
         print_time(progress.length());
         print!("] ({})", identity);

--- a/examples/progress_tracker.rs
+++ b/examples/progress_tracker.rs
@@ -1,0 +1,79 @@
+extern crate mpris;
+use mpris::{PlayerFinder, Metadata, PlaybackStatus, Progress};
+use std::io::{stdout, Write};
+use std::time::Duration;
+
+fn reset_line() {
+    print!("\r\x1b[K");
+}
+
+fn print_duration(duration: Duration) {
+    let secs = duration.as_secs();
+    let whole_hours = secs / (60 * 60);
+
+    let secs = secs - whole_hours * 60 * 60;
+    let whole_minutes = secs / 60;
+
+    let secs = secs - whole_minutes * 60;
+
+    print!("{:02}:{:02}:{:02}", whole_hours, whole_minutes, secs)
+}
+
+fn print_time(duration: Option<Duration>) {
+    match duration {
+        Some(duration) => print_duration(duration),
+        None => print!("??:??:??"),
+    }
+}
+
+fn print_artist(metadata: &Metadata) {
+    if let Some(ref artists) = metadata.artists {
+        if artists.len() > 0 {
+            print!("{}", artists.join(" + "));
+            return;
+        }
+    }
+
+    print!("Unknown artist");
+}
+
+fn print_title(metadata: &Metadata) {
+    if let Some(ref title) = metadata.title {
+        print!("{}", title);
+        return;
+    }
+
+    print!("Unknown title");
+}
+
+fn print_playback_status(progress: &Progress) {
+    match progress.playback_status {
+        PlaybackStatus::Playing => print!("▶"),
+        PlaybackStatus::Paused => print!("▮▮"),
+        PlaybackStatus::Stopped => print!("◼"),
+    }
+}
+
+fn main() {
+    let player_finder = PlayerFinder::new().unwrap();
+    let player = player_finder.find_active().unwrap();
+    let identity = player.identity();
+
+    let mut progress_tracker = player.track_progress(100).unwrap();
+    loop {
+        let progress = progress_tracker.tick();
+
+        reset_line();
+        print_playback_status(&progress);
+        print!("\t");
+        print_artist(&progress.metadata);
+        print!(" - ");
+        print_title(&progress.metadata);
+        print!(" [");
+        print_time(progress.position());
+        print!(" / ");
+        print_time(progress.length());
+        print!("] ({})", identity);
+        stdout().flush().unwrap();
+    }
+}

--- a/examples/progress_tracker.rs
+++ b/examples/progress_tracker.rs
@@ -60,7 +60,7 @@ fn main() {
 
     let mut progress_tracker = player.track_progress(100).unwrap();
     loop {
-        let progress = progress_tracker.tick();
+        let (progress, _did_refresh) = progress_tracker.tick();
 
         reset_line();
         print_playback_status(&progress);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,10 @@ pub mod errors {
 
 mod generated;
 
-mod player;
 mod find;
 mod metadata;
+mod player;
+mod progress;
 
 mod prelude {
     pub use errors::*;
@@ -81,6 +82,7 @@ mod prelude {
 pub use find::PlayerFinder;
 pub use metadata::Metadata;
 pub use player::Player;
+pub use progress::Progress;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[allow(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub mod errors {
 
 mod generated;
 
+mod pooled_connection;
 mod find;
 mod metadata;
 mod player;

--- a/src/player.rs
+++ b/src/player.rs
@@ -115,6 +115,8 @@ impl<'a> Player<'a> {
         &self.identity
     }
 
+    /// Returns the player's MPRIS `position` as a count of microseconds since the start of the
+    /// media.
     pub fn get_position_in_microseconds(&self) -> Result<u64> {
         self.connection_path()
             .get_position()
@@ -122,6 +124,9 @@ impl<'a> Player<'a> {
             .map_err(|e| e.into())
     }
 
+    /// Returns the player's MPRIS (playback) `rate` as a factor.
+    ///
+    /// 1.0 would mean normal rate, while 2.0 would mean twice the playback speed.
     pub fn get_playback_rate(&self) -> Result<f32> {
         self.connection_path()
             .get_rate()
@@ -139,6 +144,10 @@ impl<'a> Player<'a> {
             .and_then(Metadata::new_from_dbus)
     }
 
+    /// Returns a new `ProgressTracker` for the player.
+    ///
+    /// Use this if you want to monitor a player in order to show close-to-realtime information
+    /// about it.
     pub fn track_progress(&self, interval_ms: u32) -> Result<ProgressTracker> {
         self.get_metadata().and_then(|metadata| {
             self.get_playback_status().and_then(|playback_status| {

--- a/src/player.rs
+++ b/src/player.rs
@@ -149,11 +149,7 @@ impl<'a> Player<'a> {
     /// Use this if you want to monitor a player in order to show close-to-realtime information
     /// about it.
     pub fn track_progress(&self, interval_ms: u32) -> Result<ProgressTracker> {
-        self.get_metadata().and_then(|metadata| {
-            self.get_playback_status().and_then(|playback_status| {
-                ProgressTracker::new(&self, interval_ms, metadata, playback_status)
-            })
-        })
+        ProgressTracker::new(&self, interval_ms)
     }
 
     pub(crate) fn connection(&self) -> &PooledConnection {

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -1,0 +1,32 @@
+use super::prelude::*;
+use dbus::{Connection, BusType, Path, ConnPath, BusName};
+
+#[derive(Debug)]
+pub(crate) struct PooledConnection {
+    connection: Connection,
+}
+
+impl PooledConnection {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Connection::get_private(BusType::Session)?.into())
+    }
+
+    pub(crate) fn with_path<'a>(
+        &'a self,
+        bus_name: BusName<'a>,
+        path: Path<'a>,
+        timeout_ms: i32,
+    ) -> ConnPath<&'a Connection> {
+        self.connection.with_path(bus_name, path, timeout_ms)
+    }
+
+    pub(crate) fn underlying(&self) -> &Connection {
+        &self.connection
+    }
+}
+
+impl From<Connection> for PooledConnection {
+    fn from(connection: Connection) -> Self {
+        PooledConnection { connection: connection }
+    }
+}

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -1,11 +1,13 @@
 use super::prelude::*;
 use dbus::{Connection, BusType, Path, ConnPath, BusName};
+use progress::DurationExtensions;
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 pub(crate) struct PooledConnection {
     connection: Connection,
+    last_tick: Instant,
     last_event: HashMap<String, Instant>,
 }
 
@@ -16,6 +18,7 @@ impl PooledConnection {
         );
         PooledConnection {
             connection: connection,
+            last_tick: Instant::now(),
             last_event: HashMap::new(),
         }
     }
@@ -31,6 +34,37 @@ impl PooledConnection {
 
     pub(crate) fn underlying(&self) -> &Connection {
         &self.connection
+    }
+
+    pub(crate) fn process_events_blocking(&self, duration: Duration) -> bool {
+        // Try to read messages util time is up. Keep going with smaller and smaller windows until
+        // our time is up.
+        let start = Instant::now();
+        let mut should_refresh = false;
+
+        while start.elapsed() < duration {
+            let ms_left = duration
+                .checked_sub(start.elapsed())
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            // Don't bother if we have very little time left
+            if ms_left < 2 {
+                break;
+            }
+            match self.connection.incoming(ms_left as u32).next() {
+                Some(n) => {
+                    // If it's a matching message, we should refresh.
+                    // TODO: Don't refresh on all messages.
+                    should_refresh = true;
+                }
+                None => {
+                    // Time is up. No more messages.
+                    break;
+                }
+            }
+        }
+
+        should_refresh
     }
 }
 

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -1,4 +1,4 @@
-use dbus::{Connection, Path, ConnPath, BusName, Member, Message};
+use dbus::{Connection, Path, ConnPath, BusName, Message};
 use player::MPRIS2_PATH;
 use progress::DurationExtensions;
 use std::cell::RefCell;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -66,7 +66,9 @@ impl<'a> ProgressTracker<'a> {
         }
     }
 
-    pub fn tick(&mut self) -> &Progress {
+    pub fn tick(&mut self) -> (&Progress, bool) {
+        let mut did_refresh = false;
+
         // Calculate time left until we're expected to return with new data.
         let time_left = self.interval
             .checked_sub(self.last_tick.elapsed())
@@ -84,11 +86,12 @@ impl<'a> ProgressTracker<'a> {
             )
         {
             if last_event_at > self.last_tick {
+                did_refresh = true;
                 self.refresh();
             }
         }
 
-        return self.progress();
+        return (self.progress(), did_refresh);
     }
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -47,9 +47,6 @@ impl<'a> ProgressTracker<'a> {
         metadata: Metadata,
         playback_status: PlaybackStatus,
     ) -> Result<Self> {
-        player.connection().underlying().add_match(
-            "interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/mpris/MediaPlayer2'",
-        )?;
         Ok(ProgressTracker {
             player: player,
             interval: Duration::from_millis(interval_ms as u64),

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -60,12 +60,11 @@ impl<'a> ProgressTracker<'a> {
     /// See `tick` for more information about that.
     ///
     /// You probably want to use `Player::track_progress` instead of this method.
-    pub fn new(
-        player: &'a Player<'a>,
-        interval_ms: u32,
-        metadata: Metadata,
-        playback_status: PlaybackStatus,
-    ) -> Result<Self> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error in case Player metadata or state retrieval over DBus fails.
+    pub fn new(player: &'a Player<'a>, interval_ms: u32) -> Result<Self> {
         Ok(ProgressTracker {
             player: player,
             interval: Duration::from_millis(interval_ms as u64),

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,151 @@
+use super::PlaybackStatus;
+use dbus::Connection;
+use metadata::Metadata;
+use player::Player;
+use prelude::*;
+use std::ops::Deref;
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+pub struct Progress {
+    pub metadata: Metadata,
+    pub playback_status: PlaybackStatus,
+    instant: Instant,
+    position_in_microseconds: u64,
+    rate: f32,
+}
+
+#[derive(Debug)]
+pub struct ProgressTracker<'conn, C: 'conn + Deref<Target = Connection>> {
+    player: &'conn Player<'conn, C>,
+    interval: Duration,
+    last_tick: Instant,
+    last_progress: Progress,
+}
+
+trait DurationExtensions {
+    fn from_micros(u64) -> Duration;
+    fn as_millis(&self) -> u64;
+}
+
+impl DurationExtensions for Duration {
+    fn from_micros(micros: u64) -> Duration {
+        Duration::from_millis(micros / 1000)
+    }
+
+    fn as_millis(&self) -> u64 {
+        self.as_secs() * 1000 + (self.subsec_nanos() / 1000 / 1000) as u64
+    }
+}
+
+impl<'conn, C: 'conn + Deref<Target = Connection>> ProgressTracker<'conn, C> {
+    pub fn new(
+        player: &'conn Player<'conn, C>,
+        interval_ms: u32,
+        metadata: Metadata,
+        playback_status: PlaybackStatus,
+    ) -> Result<Self> {
+        player.connection().add_match(
+            "interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/mpris/MediaPlayer2'",
+        )?;
+        Ok(ProgressTracker {
+            player: player,
+            interval: Duration::from_millis(interval_ms as u64),
+            last_tick: Instant::now(),
+            last_progress: Progress::from_player(player)?,
+        })
+    }
+
+    fn progress(&mut self) -> &Progress {
+        self.last_tick = Instant::now();
+        &self.last_progress
+    }
+
+    fn refresh(&mut self) {
+        if let Ok(progress) = Progress::from_player(self.player) {
+            self.last_progress = progress;
+        }
+    }
+
+    pub fn tick(&mut self) -> &Progress {
+        let mut should_refresh = false;
+
+        // Is time already up?
+        if self.last_tick.elapsed() >= self.interval {
+            return self.progress();
+        }
+
+        // Try to read messages util time is up. Keep going with smaller and smaller windows until
+        // our time is up.
+        loop {
+            let ms_left = self.interval
+                .checked_sub(self.last_tick.elapsed())
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            // Don't bother if we have very little time left
+            if ms_left < 2 {
+                break;
+            }
+            match self.player.connection().incoming(ms_left as u32).next() {
+                Some(_) => {
+                    // If it's a matching message, we should refresh.
+                    // TODO: Don't refresh on all messages.
+                    should_refresh = true;
+                }
+                None => {
+                    // Time is up. No more messages.
+                    break;
+                }
+            }
+        }
+
+
+        if should_refresh {
+            self.refresh();
+        }
+
+        return self.progress();
+    }
+}
+
+impl Progress {
+    fn from_player<'conn, C: 'conn + Deref<Target = Connection>>(
+        player: &Player<'conn, C>,
+    ) -> Result<Progress> {
+        Ok(Progress {
+            metadata: player.get_metadata()?,
+            playback_status: player.get_playback_status()?,
+            rate: player.get_playback_rate()?,
+            position_in_microseconds: player.get_position_in_microseconds()?,
+            instant: Instant::now(),
+        })
+    }
+
+    pub fn length(&self) -> Option<Duration> {
+        self.metadata.length_in_microseconds.map(
+            Duration::from_micros,
+        )
+    }
+
+    pub fn position(&self) -> Option<Duration> {
+        self.initial_position().and_then(|pos| {
+            let elapsed_ms = self.instant.elapsed().as_millis() as f32 * self.rate;
+            pos.checked_add(Duration::from_millis(elapsed_ms as u64))
+        })
+    }
+
+    pub fn initial_position(&self) -> Option<Duration> {
+        Some(Duration::from_micros(self.position_in_microseconds))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_calculates_whole_millis_from_durations() {
+        let duration = Duration::new(5, 543_210_000);
+        assert_eq!(duration.as_millis(), 5543);
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -25,12 +25,13 @@ pub struct ProgressTracker<'conn, C: 'conn + Deref<Target = Connection>> {
 }
 
 trait DurationExtensions {
-    fn from_micros(u64) -> Duration;
+    // Rust beta has a from_micros function that is unstable.
+    fn from_micros_ext(u64) -> Duration;
     fn as_millis(&self) -> u64;
 }
 
 impl DurationExtensions for Duration {
-    fn from_micros(micros: u64) -> Duration {
+    fn from_micros_ext(micros: u64) -> Duration {
         Duration::from_millis(micros / 1000)
     }
 
@@ -124,7 +125,7 @@ impl Progress {
 
     pub fn length(&self) -> Option<Duration> {
         self.metadata.length_in_microseconds.map(
-            Duration::from_micros,
+            Duration::from_micros_ext,
         )
     }
 
@@ -136,7 +137,7 @@ impl Progress {
 
     pub fn initial_position(&self) -> Option<Duration> {
         if self.supports_position() {
-            Some(Duration::from_micros(self.position_in_microseconds))
+            Some(Duration::from_micros_ext(self.position_in_microseconds))
         } else {
             None
         }
@@ -206,7 +207,7 @@ mod test {
 
         assert_eq!(
             progress.initial_position().unwrap(),
-            Duration::from_micros(1)
+            Duration::from_micros_ext(1)
         );
         assert!(progress.position().unwrap() >= progress.initial_position().unwrap());
     }


### PR DESCRIPTION
Refs #5.

* Interval time is set manually by client to set reasonable resource usage.
* Progress calculates expected position from the last reading and current playback rate.
* If a `PropertiesChanged` event is emitted, it will re-read metadata again, else it will reuse the old object.
* Adds an example that shows playback status live.

**TODO:**
 - [x] Discriminate the messages on the D-BUS connection.
 - [x] How can we make this safer?
    - Player needs to own the connection now so no one else will use the message inbox.
    - There should probably be only one connection per player. Can we make that happen?
    - If Player gets their own connections, etc., how do we make the `all_players` method performant?
 Should there be a `PlayerStub` or something? Keep supporting showing all active players.
  - [x] Can we tag the Progress somehow so client knows if it has been
reloaded or not? Seems useful to know.
 - [x] Also look at the `Seeked` signal (for when playback rate changes).
- [x] Add documentation when API is working well.

**PS.** It sucks that Spotify on Linux does not expose the `Position` field at all. I need to find some other media player to use while testing this.