### PR TITLE
Remove Spotify detection from Progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `failure` replaces `error_chain` for error handling.
-  - All errors now implements the `failure::Fail` trait, and methods return more fine-grained `Result`s.
+  - All errors now implements the `failure::Fail` trait, and methods return
+    more fine-grained `Result`s.
+
+### Removed
+
+- The `supports_progress` method is removed from `Progress`.
+  - This is better left to clients to do themselves as this library cannot
+    guarantee anything anyway.
 
 ## 0.1.0 - 2017-12-29
 

--- a/examples/control.rs
+++ b/examples/control.rs
@@ -162,6 +162,7 @@ impl<'a> App<'a> {
     }
 
     fn tick_progress_and_refresh(&mut self, should_refresh: bool) {
+        let supports_position = self.supports_position();
         let (progress, was_changed) = self.progress_tracker.tick();
 
         // Dirty tracking to keep CPU usage lower. In case nothing happened since the last refresh,
@@ -173,13 +174,17 @@ impl<'a> App<'a> {
             clear_screen(&mut self.screen);
             print_instructions(&mut self.screen, self.player);
             print_track_info(&mut self.screen, progress);
-            print_progress_bar(&mut self.screen, progress);
-        } else if progress.supports_position() {
+            print_progress_bar(&mut self.screen, progress, supports_position);
+        } else if supports_position {
             clear_progress_bar(&mut self.screen);
-            print_progress_bar(&mut self.screen, progress);
+            print_progress_bar(&mut self.screen, progress, supports_position);
         }
 
         self.screen.flush().unwrap();
+    }
+
+    fn supports_position(&self) -> bool {
+        self.player.identity() != "Spotify"
     }
 }
 
@@ -292,8 +297,8 @@ fn print_track_info(screen: &mut Screen, progress: &Progress) {
     ).unwrap();
 }
 
-fn print_progress_bar(screen: &mut Screen, progress: &Progress) {
-    let position_string: Cow<str> = if progress.supports_position() {
+fn print_progress_bar(screen: &mut Screen, progress: &Progress, supports_position: bool) {
+    let position_string: Cow<str> = if supports_position {
         Cow::Owned(format_duration(progress.position()))
     } else {
         Cow::Borrowed("??:??:??")

--- a/examples/progress_tracker.rs
+++ b/examples/progress_tracker.rs
@@ -89,7 +89,7 @@ fn main() {
         print!(" - ");
         print_title(&progress.metadata);
         print!(" [");
-        if progress.supports_position() {
+        if identity != "Spotify" {
             print_time(Some(progress.position()));
         } else {
             print_time(None);


### PR DESCRIPTION
It's better to leave this to clients. It's going to be impossible to keep track of all the different player configurations out there and having this check inside the library means that extra confidence could be placed on the method by some users, despite it being so "stupid".

Maybe the examples doing this check manually will be enough for some users to see how to deal with it, or maybe it would be more interesting with a larger example only around trying to detect this problem.