### PR TITLE
Extend the position APIs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,29 @@ impl LoopStatus {
     }
 }
 
+/// Represents [the MPRIS `Track_Id` type][track_id].
+///
+/// ```rust
+/// use mpris::TrackID;
+/// let no_track = TrackID::from("/org/mpris/MediaPlayer2/TrackList/NoTrack");
+/// ```
+///
+/// **Note:** There is currently no good way to retrieve values for this through the `mpris`
+/// library. You will have to manually retrieve them through D-Bus until implemented.
+///
+/// [track_id]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Simple-Type:Track_Id
+#[derive(Debug, Clone)]
+pub struct TrackID<'a>(pub(crate) dbus::Path<'a>);
+
+impl<'a, T> From<T> for TrackID<'a>
+where
+    T: Into<dbus::Path<'a>>,
+{
+    fn from(value: T) -> TrackID<'a> {
+        TrackID(value.into())
+    }
+}
+
 /// Something went wrong when communicating with the D-Bus. This could either be an underlying
 /// D-Bus library problem, or that the other side did not conform to the expected protocols.
 #[derive(Fail, Debug)]
@@ -159,6 +182,24 @@ impl From<InvalidLoopStatus> for DBusError {
     fn from(error: InvalidLoopStatus) -> Self {
         DBusError {
             message: error.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod track_id {
+        use super::*;
+
+        #[test]
+        fn it_creates_track_ids() {
+            let _: TrackID = "/org/mpris/MediaPlayer2/TrackList/NoTrack".into();
+            let _: TrackID = TrackID::from("/org/mpris/MediaPlayer2/TrackList/NoTrack");
+
+            let _: TrackID =
+                TrackID::from(String::from("/org/mpris/MediaPlayer2/TrackList/NoTrack"));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,11 @@ impl LoopStatus {
 /// **Note:** There is currently no good way to retrieve values for this through the `mpris`
 /// library. You will have to manually retrieve them through D-Bus until implemented.
 ///
+/// # Panics
+///
+/// Trying to construct a `TrackID` from a string that is not a valid D-Bus Path will result in a
+/// panic.
+///
 /// [track_id]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Simple-Type:Track_Id
 #[derive(Debug, Clone)]
 pub struct TrackID<'a>(pub(crate) dbus::Path<'a>);

--- a/src/player.rs
+++ b/src/player.rs
@@ -119,6 +119,12 @@ impl<'a> Player<'a> {
         &self.identity
     }
 
+    /// Returns the player's MPRIS `position` as a `Duration` since the start of the media.
+    pub fn get_position(&self) -> Result<Duration, DBusError> {
+        self.get_position_in_microseconds()
+            .map(|us| Duration::from_micros_ext(us))
+    }
+
     /// Returns the player's MPRIS `position` as a count of microseconds since the start of the
     /// media.
     pub fn get_position_in_microseconds(&self) -> Result<u64, DBusError> {
@@ -126,6 +132,22 @@ impl<'a> Player<'a> {
             .get_position()
             .map(|p| p as u64)
             .map_err(|e| e.into())
+    }
+
+    /// Sets the position of the current track to the given position (as a `Duration`).
+    ///
+    /// Current `TrackID` must be provided to avoid race conditions with the player, in case it
+    /// changes tracks while the signal is being sent.
+    ///
+    /// **Note:** There is currently no good way to retrieve the current `TrackID` through the
+    /// `mpris` library. You will have to manually retrieve it through D-Bus until implemented.
+    ///
+    /// See: [MPRIS2 specification about `SetPosition`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:SetPosition)
+    pub fn set_position<'id, ID>(&self, track_id: ID, position: &Duration) -> Result<(), DBusError>
+    where
+        ID: Into<TrackID<'id>>,
+    {
+        self.set_position_in_microseconds(track_id, position.as_micros())
     }
 
     /// Sets the position of the current track to the given position (in microseconds).
@@ -140,13 +162,13 @@ impl<'a> Player<'a> {
     pub fn set_position_in_microseconds<'id, ID>(
         &self,
         track_id: ID,
-        position_in_us: i64,
+        position_in_us: u64,
     ) -> Result<(), DBusError>
     where
         ID: Into<TrackID<'id>>,
     {
         self.connection_path()
-            .set_position(track_id.into().0, position_in_us)
+            .set_position(track_id.into().0, position_in_us as i64)
             .map_err(|e| e.into())
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use dbus::{BusName, ConnPath, Connection, Path};
 
-use super::{DBusError, LoopStatus, PlaybackStatus};
+use super::{DBusError, LoopStatus, PlaybackStatus, TrackID};
 use extensions::DurationExtensions;
 use generated::OrgMprisMediaPlayer2;
 use generated::OrgMprisMediaPlayer2Player;
@@ -125,6 +125,28 @@ impl<'a> Player<'a> {
         self.connection_path()
             .get_position()
             .map(|p| p as u64)
+            .map_err(|e| e.into())
+    }
+
+    /// Sets the position of the current track to the given position (in microseconds).
+    ///
+    /// Current `TrackID` must be provided to avoid race conditions with the player, in case it
+    /// changes tracks while the signal is being sent.
+    ///
+    /// **Note:** There is currently no good way to retrieve the current `TrackID` through the
+    /// `mpris` library. You will have to manually retrieve it through D-Bus until implemented.
+    ///
+    /// See: [MPRIS2 specification about `SetPosition`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:SetPosition)
+    pub fn set_position_in_microseconds<'id, ID>(
+        &self,
+        track_id: ID,
+        position_in_us: i64,
+    ) -> Result<(), DBusError>
+    where
+        ID: Into<TrackID<'id>>,
+    {
+        self.connection_path()
+            .set_position(track_id.into().0, position_in_us)
             .map_err(|e| e.into())
     }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -22,7 +22,7 @@ pub struct Progress {
     /// When this Progress was constructed, in order to calculate how old it is.
     instant: Instant,
 
-    position_in_microseconds: u64,
+    position: Duration,
     rate: f32,
     current_volume: f64,
 }
@@ -184,7 +184,7 @@ impl Progress {
             shuffle: player.get_shuffle()?,
             loop_status: player.get_loop_status()?,
             rate: player.get_playback_rate()?,
-            position_in_microseconds: player.get_position_in_microseconds()?,
+            position: player.get_position()?,
             current_volume: player.get_volume()?,
             instant: Instant::now(),
         })
@@ -229,14 +229,14 @@ impl Progress {
     /// `Playing` `PlaybackStatus` and if both are `0`, then it is likely that this client does not
     /// support positions.
     pub fn position(&self) -> Duration {
-        self.initial_position() + self.elapsed()
+        self.position + self.elapsed()
     }
 
     /// Returns the position that the current track was at when the `Progress` was created.
     ///
     /// This is the number that was returned for the `Position` property in the MPRIS2 interface.
     pub fn initial_position(&self) -> Duration {
-        Duration::from_micros_ext(self.position_in_microseconds)
+        self.position.clone()
     }
 
     /// The instant where this `Progress` was recorded.
@@ -281,7 +281,7 @@ mod test {
             shuffle: false,
             loop_status: LoopStatus::None,
             rate: 1.0,
-            position_in_microseconds: 1,
+            position: Duration::from_micros_ext(1),
             current_volume: 0.0,
             instant: Instant::now(),
         };
@@ -298,7 +298,7 @@ mod test {
             shuffle: false,
             loop_status: LoopStatus::None,
             rate: 1.0,
-            position_in_microseconds: 1336,
+            position: Duration::from_micros_ext(1336),
             current_volume: 0.0,
             instant: Instant::now() - Duration::from_millis(500),
         };


### PR DESCRIPTION
Fixes #17, at least partially. It's not practically possible to set position without having access to the tracklist using the `TrackList` interface. This interface is not slated for 1.0.

In addition `Player` got `get_position` (returns `Duration`) too and `Progress` now stores a `Duration` instead of microsecond count.