### PR TITLE
A blocking events iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `Player::events(&self)` returns a blocking iterator of player events.
+  - Use this to block single-threaded apps until something happens and then
+    react on this event.
+  - This is not suitable if you want to render a progress bar as it will only
+    return when something changes; if you want to render the information at a
+    regular update interval then keep using `Player::track_progress(&self)`
+    instead.
 - `MetadataValue` type, for dynamically types metadata values. This will
   replace the raw DBus values in `Metadata` in version 2.0.
 - `Player::get_metadata_hash` which returns a `Result<HashMap<String,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Player::is_running` checks if a player is still running. Use this to detect
   players shutting down.
 
+### Changed
+
+- `Metadata` can now be constructed with empty metadata; `track_id` will then be the empty string.
+  * Some players (like VLC) without any tracks on its play queue emits empty
+    metadata, which would cause this library to return an error instead of an
+    empty metadata.
+- `Metadata` now implements `Default`.
+
 ### Deprecated
 
 - `Metadata::rest` is deprecated; version 2.0 will have a method that returns

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ fn main() {
 }
 ```
 
+See the `examples` directory for more examples.
+
 ## License
 
 Copyright 2017-2018 Magnus Bergmark

--- a/examples/detecting_shutting_down.rs
+++ b/examples/detecting_shutting_down.rs
@@ -1,5 +1,6 @@
 extern crate mpris;
-use std::thread::sleep_ms;
+use std::time::Duration;
+use std::thread::sleep;
 
 use mpris::{Player, PlayerFinder};
 
@@ -9,10 +10,6 @@ fn move_cursor_up(n: usize) {
 
 fn cursor_beginning_of_line() {
     print!("\r");
-}
-
-fn cursor_start_of_next_line() {
-    print!("\r\n");
 }
 
 fn clear_to_end_of_line() {
@@ -73,6 +70,6 @@ Exit with Ctrl-C.
 
         println!("\n(Refreshing running state every second)");
         lines_drawn += 2;
-        sleep_ms(1000);
+        sleep(Duration::from_secs(1));
     }
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,6 +1,6 @@
 extern crate mpris;
 
-use mpris::PlayerFinder;
+use mpris::{Event, PlayerFinder};
 
 fn main() {
     let player = PlayerFinder::new()
@@ -15,7 +15,13 @@ fn main() {
 
     let events = player.events().expect("Could not start event stream");
     for event in events {
-        println!("{:#?}", event);
+        match event {
+            Ok(event) => println!("{:#?}", event),
+            Err(err) => {
+                println!("D-Bus error: {}. Aborting.", err);
+                break;
+            }
+        }
     }
 
     println!("Event stream ended.");

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,22 @@
+extern crate mpris;
+
+use mpris::PlayerFinder;
+
+fn main() {
+    let player = PlayerFinder::new()
+        .expect("Could not connect to D-Bus")
+        .find_active()
+        .expect("Could not find active player");
+
+    println!(
+        "Showing event stream for player {}...\n(Exit with Ctrl-C)\n",
+        player.identity()
+    );
+
+    let events = player.events().expect("Could not start event stream");
+    for event in events {
+        println!("{:#?}", event);
+    }
+
+    println!("Event stream ended.");
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,65 @@
+use super::{DBusError, PlaybackStatus, Player, Progress};
+
+#[derive(Debug, Clone, Copy)]
+pub enum Event {
+    Paused,
+    Playing,
+    Stopped,
+}
+
+#[derive(Debug)]
+pub struct PlayerEvents<'a> {
+    player: &'a Player<'a>,
+
+    buffer: Vec<Event>,
+
+    last_progress: Progress,
+}
+
+impl<'a> PlayerEvents<'a> {
+    pub fn new(player: &'a Player<'a>) -> Result<PlayerEvents<'a>, DBusError> {
+        let progress = Progress::from_player(player)?;
+        Ok(PlayerEvents {
+            player,
+            buffer: Vec::new(),
+            last_progress: progress,
+        })
+    }
+
+    fn read_events(&mut self) -> Result<(), DBusError> {
+        self.player.process_events_blocking_until_dirty();
+
+        let new_progress = Progress::from_player(self.player)?;
+
+        //
+        // Detect changes
+        //
+        match new_progress.playback_status() {
+            status if self.last_progress.playback_status() == status => {}
+            PlaybackStatus::Playing => self.buffer.push(Event::Playing),
+            PlaybackStatus::Paused => self.buffer.push(Event::Paused),
+            PlaybackStatus::Stopped => self.buffer.push(Event::Stopped),
+        }
+
+        self.last_progress = new_progress;
+        Ok(())
+    }
+}
+
+impl<'a> Iterator for PlayerEvents<'a> {
+    type Item = Result<Event, DBusError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.read_events() {
+            Ok(_) => {}
+            Err(err) => return Some(Err(err)),
+        };
+
+        debug_assert!(
+            !self.buffer.is_empty(),
+            "Internal Events buffer is empty, which should never happen!"
+        );
+        let event = self.buffer.remove(0);
+        Some(Ok(event))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,10 +45,11 @@ extern crate dbus;
 mod generated;
 mod extensions;
 
-mod pooled_connection;
+mod event;
 mod find;
 mod metadata;
 mod player;
+mod pooled_connection;
 mod progress;
 
 pub use find::{FindingError, PlayerFinder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub use find::{FindingError, PlayerFinder};
 pub use metadata::{Metadata, Value as MetadataValue, ValueKind as MetadataValueKind};
 pub use player::Player;
 pub use progress::{Progress, ProgressTracker};
+pub use event::Event;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[allow(missing_docs)]

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -48,6 +48,27 @@ impl Metadata {
         MetadataBuilder::build_from_metadata(metadata)
     }
 
+    /// Clones Metadata without the `rest` data.
+    ///
+    /// The `rest` data uses a non-cloneable type, which makes it impossible to clone a Metadata in
+    /// the 1.x series of the mpris crate. In version 2.0 this will be fixed.
+    pub fn clone_without_rest(&self) -> Metadata {
+        Metadata {
+            track_id: self.track_id.clone(),
+            album_artists: self.album_artists.clone(),
+            album_name: self.album_name.clone(),
+            art_url: self.art_url.clone(),
+            artists: self.artists.clone(),
+            auto_rating: self.auto_rating.clone(),
+            disc_number: self.disc_number.clone(),
+            length_in_microseconds: self.length_in_microseconds.clone(),
+            title: self.title.clone(),
+            track_number: self.track_number.clone(),
+            url: self.url.clone(),
+            rest: HashMap::new(),
+        }
+    }
+
     /// The track ID.
     ///
     /// Based on `mpris:trackId`

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -15,7 +15,7 @@ use super::DBusError;
 /// * [Read more about the MPRIS2 `Metadata_Map`
 /// type.](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Mapping:Metadata_Map)
 /// * [Read MPRIS v2 metadata guidelines](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/)
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Metadata {
     track_id: String,
     album_artists: Option<Vec<String>>,
@@ -39,7 +39,7 @@ impl Metadata {
     pub fn new(track_id: String) -> Self {
         let mut builder = MetadataBuilder::new();
         builder.track_id = Some(track_id);
-        builder.finish().unwrap()
+        builder.finish()
     }
 
     pub(crate) fn new_from_dbus(
@@ -73,6 +73,10 @@ impl Metadata {
     ///
     /// Based on `mpris:trackId`
     /// > A unique identity for this track within the context of an MPRIS object.
+    ///
+    /// **NOTE:** In 2.0 this will be an `Option<&str>` as players can emit empty metadata when
+    /// there is no track present. To keep this backwards compatible with 1.x it will instead be an
+    /// empty string when no track ID is present.
     pub fn track_id(&self) -> &str {
         &self.track_id
     }
@@ -286,7 +290,7 @@ impl MetadataBuilder {
             };
         }
 
-        builder.finish()
+        Ok(builder.finish())
     }
 
     fn new() -> Self {
@@ -297,27 +301,21 @@ impl MetadataBuilder {
         self.rest.insert(key, value);
     }
 
-    fn finish(self) -> Result<Metadata, DBusError> {
-        match self.track_id {
-            Some(track_id) => Ok(Metadata {
-                track_id: track_id,
+    fn finish(self) -> Metadata {
+        Metadata {
+            track_id: self.track_id.unwrap_or_else(String::new),
+            album_artists: self.album_artists,
+            album_name: self.album_name,
+            art_url: self.art_url,
+            artists: self.artists,
+            auto_rating: self.auto_rating,
+            disc_number: self.disc_number,
+            length_in_microseconds: self.length_in_microseconds,
+            title: self.title,
+            track_number: self.track_number,
+            url: self.url,
 
-                album_artists: self.album_artists,
-                album_name: self.album_name,
-                art_url: self.art_url,
-                artists: self.artists,
-                auto_rating: self.auto_rating,
-                disc_number: self.disc_number,
-                length_in_microseconds: self.length_in_microseconds,
-                title: self.title,
-                track_number: self.track_number,
-                url: self.url,
-
-                rest: self.rest,
-            }),
-            None => Err(DBusError::new(
-                "TrackId is missing from metadata; client is not conforming to MPRIS-2",
-            )),
+            rest: self.rest,
         }
     }
 }
@@ -329,6 +327,12 @@ mod tests {
     fn it_creates_new_metadata() {
         let metadata = Metadata::new(String::from("foo"));
         assert_eq!(metadata.track_id, "foo");
+    }
+
+    #[test]
+    fn it_supports_blank_metadata() {
+        let metadata = MetadataBuilder::build_from_metadata(HashMap::new()).unwrap();
+        assert_eq!(metadata.track_id, "");
     }
 
     mod rest {
@@ -346,9 +350,7 @@ mod tests {
         {
             let mut builder = metadata_builder();
             builder.add_rest(key.into(), value);
-            builder
-                .finish()
-                .expect("Failed to build Metadata for example")
+            builder.finish()
         }
 
         #[test]

--- a/src/player.rs
+++ b/src/player.rs
@@ -658,7 +658,9 @@ impl<'a> Player<'a> {
 
     /// Blocks until player gets an event on the bus.
     ///
-    /// Other player events will also be recorded, but will not cause this function to return.
+    /// Other player events will also be recorded, but will not cause this function to return. Note
+    /// that this will block forever if player is not running. Make sure to check that the player
+    /// is running before calling this method!
     pub(crate) fn process_events_blocking_until_dirty(&self) {
         self.connection
             .process_events_blocking_until_dirty(&self.unique_name);

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use dbus::{BusName, ConnPath, Connection, Message, Path};
+use dbus::{BusName, ConnPath, Connection, Member, Message, Path};
 
 use extensions::DurationExtensions;
 use player::MPRIS2_PATH;
@@ -19,11 +19,16 @@ const NAME_HAS_OWNER_TIMEOUT: i32 = 100; // ms
 
 impl PooledConnection {
     pub(crate) fn new(connection: Connection) -> Self {
+        // Subscribe to events that relate to players. See `is_watched_message` below for more
+        // details.
         let _ = connection.add_match(
             "interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/mpris/MediaPlayer2'",
         );
         let _ = connection.add_match(
             "interface='org.mpris.MediaPlayer2.Player',member='Seeked',path='/org/mpris/MediaPlayer2'",
+        );
+        let _ = connection.add_match(
+            "type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged'",
         );
         PooledConnection {
             connection: connection,
@@ -112,10 +117,11 @@ impl PooledConnection {
         }
     }
 
-    /// Block until a MPRIS2 event for the given unique bus name is detected.
+    /// Block until a MPRIS2 event for the given unique bus name is detected, or the bus disappears
+    /// (the program exits).
     ///
     /// Events for other buses will also be recorded, but the method will not return until a
-    /// matching one has been found.
+    /// matching one has been found or the bus disappears.
     pub(crate) fn process_events_blocking_until_dirty(&self, unique_name: &str) {
         // mpris2 library must have a timeout, but since this function calls it in a loop it
         // doesn't really matter what limit we set.
@@ -135,31 +141,56 @@ impl PooledConnection {
         }
     }
 
-    /// Returns true if a given D-Bus Message is a MPRIS2 event (`ProeprtiesChanged` or `Seeked`
-    /// delivered to a MPRIS2 path).
+    /// Returns true if a given D-Bus Message is a signal that is interesting for this library.
+    ///   1. MPRIS2 "Seeked" signal.
+    ///   2. D-Bus "PropertiesChanged" signal on a MPRIS2 path.
+    ///   3. D-Bus "NameOwnerChanged" signal, to detect when players disappear.
+    ///
+    /// Since the connection given to the PooledConnection could already have subscriptions that
+    /// are not listed in this file, it is important that messages are manually filtered before
+    /// acting on them.
     fn is_watched_message(message: &Message) -> bool {
-        use std::ops::Deref;
-
-        if let Some(message_path) = message.path().as_ref() {
-            if message_path.deref() != MPRIS2_PATH {
-                return false;
-            }
+        if message.sender() == Some(BusName::from("org.freedesktop.DBus")) {
+            message.member() == Some(Member::from("NameOwnerChanged"))
+        } else if message.path() == Some(Path::from(MPRIS2_PATH)) {
+            message.member() == Some(Member::from("PropertiesChanged"))
+                || message.member() == Some(Member::from("Seeked"))
+        } else {
+            false
         }
-
-        if let Some(message_member) = message.member().as_ref() {
-            if message_member.deref() == "Seeked" || message_member.deref() == "PropertiesChanged" {
-                return true;
-            }
-        }
-
-        false
     }
 
     /// Takes a message and updates the latest update time of the sender bus.
     fn process_message(&self, message: &Message) {
-        message
-            .sender()
-            .map(|unique_name| self.mark_bus_as_updated((*unique_name).to_owned()));
+        if message.member() == Some(Member::from("NameOwnerChanged")) {
+            let _ = self.process_name_owner_changed_event(message);
+        } else {
+            // Process mpris signal
+            message
+                .sender()
+                .map(|unique_name| self.mark_bus_as_updated((*unique_name).to_owned()));
+        }
+    }
+
+    fn process_name_owner_changed_event(
+        &self,
+        message: &Message,
+    ) -> Result<(), ::dbus::arg::TypeMismatchError> {
+        let mut iter = message.iter_init();
+        let name: String = iter.read()?;
+
+        if name.starts_with("org.mpris.") {
+            let old_name: String = iter.read()?;
+            let new_name: String = iter.read()?;
+
+            // If "new_name" is empty, then the bus disappeared. "Wake" any potentially waiting
+            // loop up.
+            if new_name.is_empty() {
+                self.mark_bus_as_updated(old_name);
+            }
+        }
+
+        Ok(())
     }
 
     fn mark_bus_as_updated<S: Into<String>>(&self, bus_name: S) {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -136,13 +136,11 @@ impl<'a> ProgressTracker<'a> {
         }
 
         // If we got a new event since the last time we ticked, then reload fresh data.
-        if let Some(last_event_at) = self.player
+        if self.player
             .connection()
-            .last_event_for_unique_name(self.player.unique_name())
+            .is_bus_updated_after(self.player.unique_name(), &self.last_tick)
         {
-            if last_event_at > self.last_tick {
-                did_refresh = self.refresh();
-            }
+            did_refresh = self.refresh();
         }
 
         (self.progress(), did_refresh)
@@ -177,7 +175,7 @@ impl<'a> ProgressTracker<'a> {
 }
 
 impl Progress {
-    fn from_player<'a>(player: &'a Player<'a>) -> Result<Progress, DBusError> {
+    pub(crate) fn from_player<'a>(player: &'a Player<'a>) -> Result<Progress, DBusError> {
         Ok(Progress {
             metadata: player.get_metadata()?,
             playback_status: player.get_playback_status()?,


### PR DESCRIPTION
This PR adds a `Player::events` method that gives back an iterator of events from a player. It will block until an event is found.

Events are resolved by diffing previous and current states and adding them to an internal buffer.

Hopefully this is a solution for #32. I would love it if @rubdos could try this branch out and see if it solves their problem.

This PR also uncovered even more problems with `Metadata`. I look forward to closing these issues in 2.0 later.

# Example

Running the `events` example with VLC running yielded this output after clicking around a bit:

<details>
<summary>Output</summary>

```
Showing event stream for player VLC media player...
(Exit with Ctrl-C)

VolumeChanged(
    0.589996337890625
)
VolumeChanged(
    0.899993896484375
)
LoopingChanged(
    Track
)
LoopingChanged(
    None
)
ShuffleToggled(
    true
)
ShuffleToggled(
    false
)
TrackChanged(
    Metadata {
        track_id: "/org/videolan/vlc/playlist/3",
        album_artists: None,
        album_name: None,
        art_url: None,
        artists: None,
        auto_rating: None,
        disc_number: None,
        length_in_microseconds: None,
        title: None,
        track_number: None,
        url: Some(
            "file:///home/mange/Dropbox/mp4s/skeletor%20giggles.mp4"
        ),
        rest: {}
    }
)
Playing
Paused
Stopped
Playing
VolumeChanged(
    1.0
)
Stopped
PlayerShutDown
Event stream ended.
```
</details>

# Still left to do
- [x] Update changelog

