### PR TITLE
Implement the last of the TrackList interface + update dependencies + clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ travis-ci = { repository = "Mange/mpris-rs", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-dbus = "0.6.2"
-failure = "0.1.2"
-failure_derive = "0.1.2"
+dbus = "0.6.4"
+failure = "0.1.5"
+failure_derive = "0.1.5"
 enum-kinds = "0.4.1"
 derive_is_enum_variant = "0.1.1"
 from_variants = "0.4.0"

--- a/examples/tracklist_control.rs
+++ b/examples/tracklist_control.rs
@@ -1,0 +1,103 @@
+extern crate failure;
+extern crate mpris;
+
+use failure::{format_err, Error, ResultExt};
+use mpris::{Player, PlayerFinder};
+
+fn main() {
+    match run() {
+        Ok(_) => {}
+        Err(error) => {
+            println!("Error: {}", error);
+            for (i, cause) in error.iter_causes().enumerate() {
+                print!("{}", "  ".repeat(i + 1));
+                println!("Caused by: {}", cause);
+            }
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run() -> Result<(), Error> {
+    use std::io::stdin;
+
+    let player_finder = PlayerFinder::new().context("Could not connect to D-Bus")?;
+
+    let player = player_finder
+        .find_active()
+        .context("Could not find any player")?;
+
+    println!(
+        "Found {identity} (on bus {bus_name})",
+        bus_name = player.bus_name(),
+        identity = player.identity(),
+    );
+
+    if !player.supports_track_lists() {
+        println!("Player does not support TrackList");
+        return Ok(());
+    }
+
+    let mut answer = String::new();
+
+    loop {
+        println!("What to do? [q]uit, [g]oto, [l]ist >");
+        answer.clear();
+        stdin().read_line(&mut answer)?;
+        match answer.trim() {
+            "q" | "Q" => break,
+            "l" | "L" => print_track_list(&player)?,
+            "g" | "G" => goto_track(&player)?,
+            _ => println!("I don't understand \"{}\"", answer),
+        }
+    }
+
+    Ok(())
+}
+
+fn print_track_list(player: &Player) -> Result<(), Error> {
+    let track_list = player
+        .get_track_list()
+        .context("Could not get track list for player")?;
+
+    println!("Track list:\n");
+    let iter = track_list
+        .metadata_iter(&player)
+        .context("Could not load metadata for tracks")?;
+
+    for (index, metadata) in iter.enumerate() {
+        let title = metadata.title().unwrap_or("Unknown title");
+        let artist = metadata
+            .artists()
+            .map(|list| list.join(", "))
+            .unwrap_or_else(|| "Unknown artist".into());
+
+        println!("{}. {} - {}", index + 1, artist, title);
+    }
+
+    Ok(())
+}
+
+fn goto_track(player: &Player) -> Result<(), Error> {
+    use std::io::stdin;
+
+    let track_list = player
+        .get_track_list()
+        .context("Could not get track list for player")?;
+    let len = track_list.len();
+    println!("Select track index [1-{}, q] > ", len);
+
+    let mut answer = String::new();
+    stdin().read_line(&mut answer)?;
+    let answer = answer.trim();
+
+    if answer != "q" {
+        let number: usize = answer.parse::<usize>().context("Not a valid number")?;
+        let track_id = track_list
+            .get(number.saturating_sub(1))
+            .ok_or_else(|| format_err!("Not a valid position"))?;
+        player.go_to(track_id).context("Failed to change track")?;
+    }
+
+    Ok(())
+}

--- a/script/generate-mpris-interface.sh
+++ b/script/generate-mpris-interface.sh
@@ -32,7 +32,7 @@ for spec in "$root"/mpris-spec/spec/org.mpris.*.xml; do
 
   cat <<EOF > "$dest_file"
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 #![allow(missing_debug_implementations,
         missing_copy_implementations,
         trivial_casts,

--- a/src/event.rs
+++ b/src/event.rs
@@ -192,15 +192,12 @@ impl<'a> PlayerEvents<'a> {
         }
 
         if reload_track_list && self.track_list.is_some() {
-            match self.player.checked_get_track_list()? {
-                Some(new_tracks) => {
-                    match self.track_list {
-                        Some(ref mut list) => list.replace(new_tracks),
-                        None => self.track_list = Some(new_tracks),
-                    }
-                    self.buffer.push(Event::TrackListReplaced);
+            if let Some(new_tracks) = self.player.checked_get_track_list()? {
+                match self.track_list {
+                    Some(ref mut list) => list.replace(new_tracks),
+                    None => self.track_list = Some(new_tracks),
                 }
-                _ => {}
+                self.buffer.push(Event::TrackListReplaced);
             }
         }
 

--- a/src/generated/media_player.rs
+++ b/src/generated/media_player.rs
@@ -1,5 +1,5 @@
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 #![allow(missing_debug_implementations,
         missing_copy_implementations,
         trivial_casts,

--- a/src/generated/media_player.rs
+++ b/src/generated/media_player.rs
@@ -34,16 +34,16 @@ impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2 for
     type Err = dbus::Error;
 
     fn raise(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2".into(), &"Raise".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2".into(), &"Raise".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn quit(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2".into(), &"Quit".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2".into(), &"Quit".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 

--- a/src/generated/media_player_player.rs
+++ b/src/generated/media_player_player.rs
@@ -32,7 +32,7 @@ pub trait OrgMprisMediaPlayer2Player {
     fn set_rate(&self, value: f64) -> Result<(), Self::Err>;
     fn get_shuffle(&self) -> Result<bool, Self::Err>;
     fn set_shuffle(&self, value: bool) -> Result<(), Self::Err>;
-    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg>>>, Self::Err>;
+    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Self::Err>;
     fn get_volume(&self) -> Result<f64, Self::Err>;
     fn set_volume(&self, value: f64) -> Result<(), Self::Err>;
     fn get_position(&self) -> Result<i64, Self::Err>;
@@ -50,72 +50,72 @@ impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2Play
     type Err = dbus::Error;
 
     fn next(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Next".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Next".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn previous(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Previous".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Previous".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn pause(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Pause".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Pause".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn play_pause(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"PlayPause".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"PlayPause".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn stop(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Stop".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Stop".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn play(&self) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Play".into(), |_| {
-        }));
-        try!(m.as_result());
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Play".into(), |_| {
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn seek(&self, offset: i64) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Seek".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Seek".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(offset);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn set_position(&self, track_id: dbus::Path, position: i64) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"SetPosition".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"SetPosition".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(track_id);
             i.append(position);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn open_uri(&self, uri: &str) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"OpenUri".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"OpenUri".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(uri);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
@@ -135,7 +135,7 @@ impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2Play
         <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Shuffle")
     }
 
-    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg>>>, Self::Err> {
+    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Self::Err> {
         <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Metadata")
     }
 
@@ -205,10 +205,10 @@ impl dbus::SignalArgs for OrgMprisMediaPlayer2PlayerSeeked {
     const NAME: &'static str = "Seeked";
     const INTERFACE: &'static str = "org.mpris.MediaPlayer2.Player";
     fn append(&self, i: &mut arg::IterAppend) {
-        (&self.position as &arg::RefArg).append(i);
+        arg::RefArg::append(&self.position, i);
     }
     fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.position = try!(i.read());
+        self.position = i.read()?;
         Ok(())
     }
 }

--- a/src/generated/media_player_player.rs
+++ b/src/generated/media_player_player.rs
@@ -1,5 +1,5 @@
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 #![allow(missing_debug_implementations,
         missing_copy_implementations,
         trivial_casts,

--- a/src/generated/media_player_playlists.rs
+++ b/src/generated/media_player_playlists.rs
@@ -1,5 +1,5 @@
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 #![allow(missing_debug_implementations,
         missing_copy_implementations,
         trivial_casts,

--- a/src/generated/media_player_playlists.rs
+++ b/src/generated/media_player_playlists.rs
@@ -27,25 +27,25 @@ impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2Play
     type Err = dbus::Error;
 
     fn activate_playlist(&self, playlist_id: dbus::Path) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Playlists".into(), &"ActivatePlaylist".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Playlists".into(), &"ActivatePlaylist".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(playlist_id);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn get_playlists(&self, index: u32, max_count: u32, order: &str, reverse_order: bool) -> Result<Vec<(dbus::Path<'static>, String, String)>, Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.Playlists".into(), &"GetPlaylists".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Playlists".into(), &"GetPlaylists".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(index);
             i.append(max_count);
             i.append(order);
             i.append(reverse_order);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         let mut i = m.iter_init();
-        let playlists: Vec<(dbus::Path<'static>, String, String)> = try!(i.read());
+        let playlists: Vec<(dbus::Path<'static>, String, String)> = i.read()?;
         Ok(playlists)
     }
 
@@ -71,10 +71,10 @@ impl dbus::SignalArgs for OrgMprisMediaPlayer2PlaylistsPlaylistChanged {
     const NAME: &'static str = "PlaylistChanged";
     const INTERFACE: &'static str = "org.mpris.MediaPlayer2.Playlists";
     fn append(&self, i: &mut arg::IterAppend) {
-        (&self.playlist as &arg::RefArg).append(i);
+        arg::RefArg::append(&self.playlist, i);
     }
     fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.playlist = try!(i.read());
+        self.playlist = i.read()?;
         Ok(())
     }
 }

--- a/src/generated/media_player_tracklist.rs
+++ b/src/generated/media_player_tracklist.rs
@@ -1,5 +1,5 @@
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 #![allow(missing_debug_implementations,
         missing_copy_implementations,
         trivial_casts,

--- a/src/generated/media_player_tracklist.rs
+++ b/src/generated/media_player_tracklist.rs
@@ -16,7 +16,7 @@ use dbus::arg;
 
 pub trait OrgMprisMediaPlayer2TrackList {
     type Err;
-    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg>>>>, Self::Err>;
+    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>>, Self::Err>;
     fn add_track(&self, uri: &str, after_track: dbus::Path, set_as_current: bool) -> Result<(), Self::Err>;
     fn remove_track(&self, track_id: dbus::Path) -> Result<(), Self::Err>;
     fn go_to(&self, track_id: dbus::Path) -> Result<(), Self::Err>;
@@ -27,43 +27,43 @@ pub trait OrgMprisMediaPlayer2TrackList {
 impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2TrackList for dbus::ConnPath<'a, C> {
     type Err = dbus::Error;
 
-    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg>>>>, Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"GetTracksMetadata".into(), |msg| {
+    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>>, Self::Err> {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"GetTracksMetadata".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(track_ids);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         let mut i = m.iter_init();
-        let metadata: Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg>>>> = try!(i.read());
+        let metadata: Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>> = i.read()?;
         Ok(metadata)
     }
 
     fn add_track(&self, uri: &str, after_track: dbus::Path, set_as_current: bool) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"AddTrack".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"AddTrack".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(uri);
             i.append(after_track);
             i.append(set_as_current);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn remove_track(&self, track_id: dbus::Path) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"RemoveTrack".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"RemoveTrack".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(track_id);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
     fn go_to(&self, track_id: dbus::Path) -> Result<(), Self::Err> {
-        let mut m = try!(self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"GoTo".into(), |msg| {
+        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"GoTo".into(), |msg| {
             let mut i = arg::IterAppend::new(msg);
             i.append(track_id);
-        }));
-        try!(m.as_result());
+        })?;
+        m.as_result()?;
         Ok(())
     }
 
@@ -86,19 +86,19 @@ impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackListReplaced {
     const NAME: &'static str = "TrackListReplaced";
     const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
     fn append(&self, i: &mut arg::IterAppend) {
-        (&self.tracks as &arg::RefArg).append(i);
-        (&self.current_track as &arg::RefArg).append(i);
+        arg::RefArg::append(&self.tracks, i);
+        arg::RefArg::append(&self.current_track, i);
     }
     fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.tracks = try!(i.read());
-        self.current_track = try!(i.read());
+        self.tracks = i.read()?;
+        self.current_track = i.read()?;
         Ok(())
     }
 }
 
 #[derive(Debug, Default)]
 pub struct OrgMprisMediaPlayer2TrackListTrackAdded {
-    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg>>>,
+    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>,
     pub after_track: dbus::Path<'static>,
 }
 
@@ -106,12 +106,12 @@ impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackAdded {
     const NAME: &'static str = "TrackAdded";
     const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
     fn append(&self, i: &mut arg::IterAppend) {
-        (&self.metadata as &arg::RefArg).append(i);
-        (&self.after_track as &arg::RefArg).append(i);
+        arg::RefArg::append(&self.metadata, i);
+        arg::RefArg::append(&self.after_track, i);
     }
     fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.metadata = try!(i.read());
-        self.after_track = try!(i.read());
+        self.metadata = i.read()?;
+        self.after_track = i.read()?;
         Ok(())
     }
 }
@@ -125,10 +125,10 @@ impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackRemoved {
     const NAME: &'static str = "TrackRemoved";
     const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
     fn append(&self, i: &mut arg::IterAppend) {
-        (&self.track_id as &arg::RefArg).append(i);
+        arg::RefArg::append(&self.track_id, i);
     }
     fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.track_id = try!(i.read());
+        self.track_id = i.read()?;
         Ok(())
     }
 }
@@ -136,19 +136,19 @@ impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackRemoved {
 #[derive(Debug, Default)]
 pub struct OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
     pub track_id: dbus::Path<'static>,
-    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg>>>,
+    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>,
 }
 
 impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
     const NAME: &'static str = "TrackMetadataChanged";
     const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
     fn append(&self, i: &mut arg::IterAppend) {
-        (&self.track_id as &arg::RefArg).append(i);
-        (&self.metadata as &arg::RefArg).append(i);
+        arg::RefArg::append(&self.track_id, i);
+        arg::RefArg::append(&self.metadata, i);
     }
     fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.track_id = try!(i.read());
-        self.metadata = try!(i.read());
+        self.track_id = i.read()?;
+        self.metadata = i.read()?;
         Ok(())
     }
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -162,7 +162,7 @@ impl Metadata {
 
 // Disable implicit_hasher; suggested code fix does not compile. I think this might be a false
 // positive, but I'm not sure.
-#[cfg_attr(feature = "cargo-clippy", allow(implicit_hasher))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::implicit_hasher))]
 impl From<Metadata> for HashMap<String, Value> {
     fn from(metadata: Metadata) -> Self {
         metadata.values

--- a/src/player.rs
+++ b/src/player.rs
@@ -280,7 +280,8 @@ impl<'a> Player<'a> {
             &connection_path,
             "org.mpris.MediaPlayer2.Player",
             "Metadata",
-        ).map(Metadata::from)
+        )
+        .map(Metadata::from)
         .map_err(DBusError::from)
     }
 
@@ -299,7 +300,8 @@ impl<'a> Player<'a> {
             &connection_path,
             "org.mpris.MediaPlayer2.TrackList",
             "Tracks",
-        ).map(TrackList::from)
+        )
+        .map(TrackList::from)
         .map_err(DBusError::from)
     }
 
@@ -335,7 +337,8 @@ impl<'a> Player<'a> {
             &connection_path,
             "org.mpris.MediaPlayer2.TrackList",
             "CanEditTracks",
-        ).map_err(DBusError::from)
+        )
+        .map_err(DBusError::from)
     }
 
     /// Query the player to see if it allows changes to its TrackList.
@@ -574,6 +577,21 @@ impl<'a> Player<'a> {
     /// See: `seek` method on `Player`.
     pub fn seek_backwards(&self, offset: &Duration) -> Result<(), DBusError> {
         self.seek(-(DurationExtensions::as_micros(offset) as i64))
+    }
+
+    /// Go to a specific track on the Player's TrackList.
+    ///
+    /// If the given TrackID is not part of the player's TrackList, it will have no effect.
+    ///
+    /// Requires the player to implement the `TrackList` interface.
+    ///
+    /// See: [MPRIS2 specification about `GoTo`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:GoTo)
+    pub fn go_to(&self, track_id: &TrackID) -> Result<(), DBusError> {
+        use generated::OrgMprisMediaPlayer2TrackList;
+
+        self.connection_path()
+            .go_to(track_id.into())
+            .map_err(DBusError::from)
     }
 
     /// Sends a `PlayPause` signal to the player, if the player indicates that it can pause.

--- a/src/player.rs
+++ b/src/player.rs
@@ -594,6 +594,56 @@ impl<'a> Player<'a> {
             .map_err(DBusError::from)
     }
 
+    /// Add a URI to the TrackList and optionally set it as current.
+    ///
+    /// It is placed after the specified TrackID, if supported by the player.
+    ///
+    /// Requires the player to implement the `TrackList` interface.
+    ///
+    /// See: [MPRIS2 specification about `AddTrack`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:AddTrack)
+    pub fn add_track(
+        &self,
+        uri: &str,
+        after: &TrackID,
+        set_as_current: bool,
+    ) -> Result<(), DBusError> {
+        use generated::OrgMprisMediaPlayer2TrackList;
+
+        self.connection_path()
+            .add_track(uri, after.into(), set_as_current)
+            .map_err(DBusError::from)
+    }
+
+    /// Add a URI to the start of the TrackList and optionally set it as current.
+    ///
+    /// Requires the player to implement the `TrackList` interface.
+    ///
+    /// See: [MPRIS2 specification about `AddTrack`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:AddTrack)
+    pub fn add_track_at_start(
+        &self,
+        uri: &str,
+        set_as_current: bool,
+    ) -> Result<(), DBusError> {
+        use generated::OrgMprisMediaPlayer2TrackList;
+
+        self.connection_path()
+            .add_track(uri, crate::track_list::NO_TRACK.into(), set_as_current)
+            .map_err(DBusError::from)
+    }
+
+    /// Remove an item from the TrackList.
+    ///
+    /// Requires the player to implement the `TrackList` interface.
+    ///
+    /// See: [MPRIS2 specification about `RemoveTrack`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:RemoveTrack)
+    pub fn remove_track(&self, track_id: &TrackID) -> Result<(), DBusError> {
+        use generated::OrgMprisMediaPlayer2TrackList;
+
+        self.connection_path()
+            .remove_track(track_id.into())
+            .map_err(DBusError::from)
+    }
+
     /// Sends a `PlayPause` signal to the player, if the player indicates that it can pause.
     ///
     /// Returns a boolean to show if the signal was sent or not.

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -58,7 +58,8 @@ impl PooledConnection {
             "/",
             "org.freedesktop.DBus",
             "GetNameOwner",
-        ).unwrap()
+        )
+        .unwrap()
         .append1(bus_name.into());
 
         self.connection
@@ -73,7 +74,8 @@ impl PooledConnection {
             "/",
             "org.freedesktop.DBus",
             "NameHasOwner",
-        ).unwrap()
+        )
+        .unwrap()
         .append1(bus_name.into());
 
         self.connection
@@ -194,9 +196,7 @@ impl PooledConnection {
                     .push(MprisEvent::TrackListPropertiesChanged);
             }
             MprisMessage::TrackListReplaced {
-                unique_name,
-                ids,
-                current_id: _,
+                unique_name, ids, ..
             } => {
                 events
                     .entry(unique_name)
@@ -214,7 +214,7 @@ impl PooledConnection {
                     .entry(unique_name)
                     .or_default()
                     .push(MprisEvent::TrackAdded {
-                        after_id: after_id.into(),
+                        after_id,
                         metadata: Metadata::from(metadata),
                     });
             }
@@ -222,7 +222,7 @@ impl PooledConnection {
                 events
                     .entry(unique_name)
                     .or_default()
-                    .push(MprisEvent::TrackRemoved { id: id.into() });
+                    .push(MprisEvent::TrackRemoved { id });
             }
             MprisMessage::TrackMetadataChanged {
                 unique_name,
@@ -233,7 +233,7 @@ impl PooledConnection {
                     .entry(unique_name)
                     .or_default()
                     .push(MprisEvent::TrackMetadataChanged {
-                        old_id: old_id.into(),
+                        old_id,
                         metadata: Metadata::from(metadata),
                     });
             }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -313,10 +313,7 @@ impl<'a> ProgressTracker<'a> {
 
     fn refresh_track_list(&mut self) -> bool {
         match self.track_list {
-            Some(ref mut list) => match list.reload(&self.player) {
-                Ok(_) => true,
-                Err(_) => false,
-            },
+            Some(ref mut list) => list.reload(&self.player).is_ok(),
             None => false,
         }
     }

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -186,6 +186,11 @@ impl TrackList {
         self.ids.len()
     }
 
+    /// If the tracklist is empty or not.
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
     /// Return the TrackID of the index. Out-of-bounds will result in `None`.
     pub fn get(&self, index: usize) -> Option<&TrackID> {
         self.ids.get(index)
@@ -344,11 +349,8 @@ impl TrackList {
             let mut cache = self.metadata_cache.try_borrow_mut()?;
 
             for info in metadata.into_iter() {
-                match info.track_id() {
-                    Some(id) => {
-                        cache.insert(id, info);
-                    }
-                    None => {}
+                if let Some(id) = info.track_id() {
+                    cache.insert(id, info);
                 }
             }
         }
@@ -373,7 +375,7 @@ impl TrackList {
     }
 
     fn clear_extra_cache(&mut self) {
-        let ids: Vec<TrackID> = self.ids().into_iter().map(TrackID::from).collect();
+        let ids: Vec<TrackID> = self.ids().iter().map(TrackID::from).collect();
 
         self.change_metadata(|cache| {
             // For each id in the list, move the cache out into a new HashMap, then replace the old

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::iter::{FromIterator, IntoIterator};
 
+pub(crate) const NO_TRACK: &str = "/org/mpris/MediaPlayer2/TrackList/NoTrack";
+
 /// Represents [the MPRIS `Track_Id` type][track_id].
 ///
 /// ```rust
@@ -119,6 +121,20 @@ impl TrackID {
         } else {
             Ok(TrackID(id))
         }
+    }
+
+    /// Return a new TrackID that matches the MPRIS standard for the "No track" sentinel value.
+    ///
+    /// Some APIs takes this in order to signal a missing value for a track, for example by saying
+    /// that no specific track is playing, or that a track should be added at the start of the
+    /// list instead of after a specific track.
+    ///
+    /// The actual path is "/org/mpris/MediaPlayer2/TrackList/NoTrack".
+    ///
+    /// This value is only valid in some cases. Make sure to read the MPRIS specification before
+    /// you use this manually.
+    pub fn no_track() -> Self {
+        TrackID(NO_TRACK.into())
     }
 
     /// Returns a `&str` variant of the ID.

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -86,6 +86,12 @@ impl From<TrackID> for String {
     }
 }
 
+impl<'a> From<&'a TrackID> for dbus::Path<'a> {
+    fn from(id: &'a TrackID) -> dbus::Path<'a> {
+        id.as_path()
+    }
+}
+
 impl fmt::Display for TrackID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
@@ -162,6 +168,11 @@ impl TrackList {
     /// Returns the number of tracks on the list.
     pub fn len(&self) -> usize {
         self.ids.len()
+    }
+
+    /// Return the TrackID of the index. Out-of-bounds will result in `None`.
+    pub fn get(&self, index: usize) -> Option<&TrackID> {
+        self.ids.get(index)
     }
 
     /// Insert a new track (via its metadata) after another one. If the provided ID cannot be found
@@ -356,7 +367,8 @@ impl TrackList {
                 .flat_map(|id| match cache.remove(id) {
                     Some(value) => Some((id.to_owned(), value)),
                     None => None,
-                }).collect();
+                })
+                .collect();
 
             *cache = new_cache;
         });


### PR DESCRIPTION
Add support for `GoTo`, `AddTrack`, and `RemoveTrack`. Also adds some other nice methods to `TrackList`, such as `len`, `is_empty`.

Fixes #27.