### PR TITLE
Updated to dbus-0.8.1 and fixed PlayerEvents being referenced by `Player::events` but not re-exported. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "Mange/mpris-rs", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-dbus = "0.6.4"
+dbus = "0.8.1"
 failure = "0.1.5"
 failure_derive = "0.1.5"
 enum-kinds = "0.4.1"

--- a/script/generate-mpris-interface.sh
+++ b/script/generate-mpris-interface.sh
@@ -43,7 +43,7 @@ for spec in "$root"/mpris-spec/spec/org.mpris.*.xml; do
         unused_qualifications,
         unused_imports)]
 EOF
-  dbus-codegen-rust -m None < "$spec" >> "$dest_file"
+  dbus-codegen-rust -m None -c ffidisp < "$spec" >> "$dest_file"
 done
 
 echo "Formatting code... "

--- a/src/event.rs
+++ b/src/event.rs
@@ -113,7 +113,7 @@ pub struct PlayerEvents<'a> {
 }
 
 impl<'a> PlayerEvents<'a> {
-    pub fn new(player: &'a Player<'a>) -> Result<PlayerEvents<'a>, DBusError> {
+    pub(crate) fn new(player: &'a Player<'a>) -> Result<PlayerEvents<'a>, DBusError> {
         let progress = Progress::from_player(player)?;
         Ok(PlayerEvents {
             player,
@@ -123,6 +123,7 @@ impl<'a> PlayerEvents<'a> {
         })
     }
 
+    /// Current tracklist of the player. Will be kept up to date.
     pub fn track_list(&self) -> Option<&TrackList> {
         self.track_list.as_ref()
     }

--- a/src/find.rs
+++ b/src/find.rs
@@ -2,7 +2,8 @@ extern crate dbus;
 
 use std::rc::Rc;
 
-use dbus::{arg, BusType, Connection, Message};
+use dbus::{arg, Message};
+use dbus::ffidisp::{BusType, Connection};
 
 use super::DBusError;
 use crate::player::{Player, DEFAULT_TIMEOUT_MS, MPRIS2_PATH, MPRIS2_PREFIX};

--- a/src/generated/media_player.rs
+++ b/src/generated/media_player.rs
@@ -13,77 +13,70 @@
 
 use dbus as dbus;
 use dbus::arg;
+use dbus::ffidisp;
 
 pub trait OrgMprisMediaPlayer2 {
-    type Err;
-    fn raise(&self) -> Result<(), Self::Err>;
-    fn quit(&self) -> Result<(), Self::Err>;
-    fn get_can_quit(&self) -> Result<bool, Self::Err>;
-    fn get_fullscreen(&self) -> Result<bool, Self::Err>;
-    fn set_fullscreen(&self, value: bool) -> Result<(), Self::Err>;
-    fn get_can_set_fullscreen(&self) -> Result<bool, Self::Err>;
-    fn get_can_raise(&self) -> Result<bool, Self::Err>;
-    fn get_has_track_list(&self) -> Result<bool, Self::Err>;
-    fn get_identity(&self) -> Result<String, Self::Err>;
-    fn get_desktop_entry(&self) -> Result<String, Self::Err>;
-    fn get_supported_uri_schemes(&self) -> Result<Vec<String>, Self::Err>;
-    fn get_supported_mime_types(&self) -> Result<Vec<String>, Self::Err>;
+    fn raise(&self) -> Result<(), dbus::Error>;
+    fn quit(&self) -> Result<(), dbus::Error>;
+    fn get_can_quit(&self) -> Result<bool, dbus::Error>;
+    fn get_fullscreen(&self) -> Result<bool, dbus::Error>;
+    fn set_fullscreen(&self, value: bool) -> Result<(), dbus::Error>;
+    fn get_can_set_fullscreen(&self) -> Result<bool, dbus::Error>;
+    fn get_can_raise(&self) -> Result<bool, dbus::Error>;
+    fn get_has_track_list(&self) -> Result<bool, dbus::Error>;
+    fn get_identity(&self) -> Result<String, dbus::Error>;
+    fn get_desktop_entry(&self) -> Result<String, dbus::Error>;
+    fn get_supported_uri_schemes(&self) -> Result<Vec<String>, dbus::Error>;
+    fn get_supported_mime_types(&self) -> Result<Vec<String>, dbus::Error>;
 }
 
-impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2 for dbus::ConnPath<'a, C> {
-    type Err = dbus::Error;
+impl<'a, C: ::std::ops::Deref<Target=ffidisp::Connection>> OrgMprisMediaPlayer2 for ffidisp::ConnPath<'a, C> {
 
-    fn raise(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2".into(), &"Raise".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn raise(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2", "Raise", ())
     }
 
-    fn quit(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2".into(), &"Quit".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn quit(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2", "Quit", ())
     }
 
-    fn get_can_quit(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "CanQuit")
+    fn get_can_quit(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "CanQuit")
     }
 
-    fn get_fullscreen(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "Fullscreen")
+    fn get_fullscreen(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "Fullscreen")
     }
 
-    fn get_can_set_fullscreen(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "CanSetFullscreen")
+    fn get_can_set_fullscreen(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "CanSetFullscreen")
     }
 
-    fn get_can_raise(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "CanRaise")
+    fn get_can_raise(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "CanRaise")
     }
 
-    fn get_has_track_list(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "HasTrackList")
+    fn get_has_track_list(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "HasTrackList")
     }
 
-    fn get_identity(&self) -> Result<String, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "Identity")
+    fn get_identity(&self) -> Result<String, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "Identity")
     }
 
-    fn get_desktop_entry(&self) -> Result<String, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "DesktopEntry")
+    fn get_desktop_entry(&self) -> Result<String, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "DesktopEntry")
     }
 
-    fn get_supported_uri_schemes(&self) -> Result<Vec<String>, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "SupportedUriSchemes")
+    fn get_supported_uri_schemes(&self) -> Result<Vec<String>, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "SupportedUriSchemes")
     }
 
-    fn get_supported_mime_types(&self) -> Result<Vec<String>, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "SupportedMimeTypes")
+    fn get_supported_mime_types(&self) -> Result<Vec<String>, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2", "SupportedMimeTypes")
     }
 
-    fn set_fullscreen(&self, value: bool) -> Result<(), Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2", "Fullscreen", value)
+    fn set_fullscreen(&self, value: bool) -> Result<(), dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2", "Fullscreen", value)
     }
 }

--- a/src/generated/media_player_player.rs
+++ b/src/generated/media_player_player.rs
@@ -13,202 +13,174 @@
 
 use dbus as dbus;
 use dbus::arg;
+use dbus::ffidisp;
 
 pub trait OrgMprisMediaPlayer2Player {
-    type Err;
-    fn next(&self) -> Result<(), Self::Err>;
-    fn previous(&self) -> Result<(), Self::Err>;
-    fn pause(&self) -> Result<(), Self::Err>;
-    fn play_pause(&self) -> Result<(), Self::Err>;
-    fn stop(&self) -> Result<(), Self::Err>;
-    fn play(&self) -> Result<(), Self::Err>;
-    fn seek(&self, offset: i64) -> Result<(), Self::Err>;
-    fn set_position(&self, track_id: dbus::Path, position: i64) -> Result<(), Self::Err>;
-    fn open_uri(&self, uri: &str) -> Result<(), Self::Err>;
-    fn get_playback_status(&self) -> Result<String, Self::Err>;
-    fn get_loop_status(&self) -> Result<String, Self::Err>;
-    fn set_loop_status(&self, value: String) -> Result<(), Self::Err>;
-    fn get_rate(&self) -> Result<f64, Self::Err>;
-    fn set_rate(&self, value: f64) -> Result<(), Self::Err>;
-    fn get_shuffle(&self) -> Result<bool, Self::Err>;
-    fn set_shuffle(&self, value: bool) -> Result<(), Self::Err>;
-    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Self::Err>;
-    fn get_volume(&self) -> Result<f64, Self::Err>;
-    fn set_volume(&self, value: f64) -> Result<(), Self::Err>;
-    fn get_position(&self) -> Result<i64, Self::Err>;
-    fn get_minimum_rate(&self) -> Result<f64, Self::Err>;
-    fn get_maximum_rate(&self) -> Result<f64, Self::Err>;
-    fn get_can_go_next(&self) -> Result<bool, Self::Err>;
-    fn get_can_go_previous(&self) -> Result<bool, Self::Err>;
-    fn get_can_play(&self) -> Result<bool, Self::Err>;
-    fn get_can_pause(&self) -> Result<bool, Self::Err>;
-    fn get_can_seek(&self) -> Result<bool, Self::Err>;
-    fn get_can_control(&self) -> Result<bool, Self::Err>;
+    fn next(&self) -> Result<(), dbus::Error>;
+    fn previous(&self) -> Result<(), dbus::Error>;
+    fn pause(&self) -> Result<(), dbus::Error>;
+    fn play_pause(&self) -> Result<(), dbus::Error>;
+    fn stop(&self) -> Result<(), dbus::Error>;
+    fn play(&self) -> Result<(), dbus::Error>;
+    fn seek(&self, offset: i64) -> Result<(), dbus::Error>;
+    fn set_position(&self, track_id: dbus::Path, position: i64) -> Result<(), dbus::Error>;
+    fn open_uri(&self, uri: &str) -> Result<(), dbus::Error>;
+    fn get_playback_status(&self) -> Result<String, dbus::Error>;
+    fn get_loop_status(&self) -> Result<String, dbus::Error>;
+    fn set_loop_status(&self, value: String) -> Result<(), dbus::Error>;
+    fn get_rate(&self) -> Result<f64, dbus::Error>;
+    fn set_rate(&self, value: f64) -> Result<(), dbus::Error>;
+    fn get_shuffle(&self) -> Result<bool, dbus::Error>;
+    fn set_shuffle(&self, value: bool) -> Result<(), dbus::Error>;
+    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, dbus::Error>;
+    fn get_volume(&self) -> Result<f64, dbus::Error>;
+    fn set_volume(&self, value: f64) -> Result<(), dbus::Error>;
+    fn get_position(&self) -> Result<i64, dbus::Error>;
+    fn get_minimum_rate(&self) -> Result<f64, dbus::Error>;
+    fn get_maximum_rate(&self) -> Result<f64, dbus::Error>;
+    fn get_can_go_next(&self) -> Result<bool, dbus::Error>;
+    fn get_can_go_previous(&self) -> Result<bool, dbus::Error>;
+    fn get_can_play(&self) -> Result<bool, dbus::Error>;
+    fn get_can_pause(&self) -> Result<bool, dbus::Error>;
+    fn get_can_seek(&self) -> Result<bool, dbus::Error>;
+    fn get_can_control(&self) -> Result<bool, dbus::Error>;
 }
 
-impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2Player for dbus::ConnPath<'a, C> {
-    type Err = dbus::Error;
+impl<'a, C: ::std::ops::Deref<Target=ffidisp::Connection>> OrgMprisMediaPlayer2Player for ffidisp::ConnPath<'a, C> {
 
-    fn next(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Next".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn next(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "Next", ())
     }
 
-    fn previous(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Previous".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn previous(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "Previous", ())
     }
 
-    fn pause(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Pause".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn pause(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "Pause", ())
     }
 
-    fn play_pause(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"PlayPause".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn play_pause(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "PlayPause", ())
     }
 
-    fn stop(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Stop".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn stop(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "Stop", ())
     }
 
-    fn play(&self) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Play".into(), |_| {
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn play(&self) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "Play", ())
     }
 
-    fn seek(&self, offset: i64) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"Seek".into(), |msg| {
-            let mut i = arg::IterAppend::new(msg);
-            i.append(offset);
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn seek(&self, offset: i64) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "Seek", (offset, ))
     }
 
-    fn set_position(&self, track_id: dbus::Path, position: i64) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"SetPosition".into(), |msg| {
-            let mut i = arg::IterAppend::new(msg);
-            i.append(track_id);
-            i.append(position);
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn set_position(&self, track_id: dbus::Path, position: i64) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "SetPosition", (track_id, position, ))
     }
 
-    fn open_uri(&self, uri: &str) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.Player".into(), &"OpenUri".into(), |msg| {
-            let mut i = arg::IterAppend::new(msg);
-            i.append(uri);
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn open_uri(&self, uri: &str) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.Player", "OpenUri", (uri, ))
     }
 
-    fn get_playback_status(&self) -> Result<String, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "PlaybackStatus")
+    fn get_playback_status(&self) -> Result<String, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "PlaybackStatus")
     }
 
-    fn get_loop_status(&self) -> Result<String, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "LoopStatus")
+    fn get_loop_status(&self) -> Result<String, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "LoopStatus")
     }
 
-    fn get_rate(&self) -> Result<f64, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Rate")
+    fn get_rate(&self) -> Result<f64, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Rate")
     }
 
-    fn get_shuffle(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Shuffle")
+    fn get_shuffle(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Shuffle")
     }
 
-    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Metadata")
+    fn get_metadata(&self) -> Result<::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Metadata")
     }
 
-    fn get_volume(&self) -> Result<f64, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Volume")
+    fn get_volume(&self) -> Result<f64, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Volume")
     }
 
-    fn get_position(&self) -> Result<i64, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Position")
+    fn get_position(&self) -> Result<i64, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "Position")
     }
 
-    fn get_minimum_rate(&self) -> Result<f64, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "MinimumRate")
+    fn get_minimum_rate(&self) -> Result<f64, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "MinimumRate")
     }
 
-    fn get_maximum_rate(&self) -> Result<f64, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "MaximumRate")
+    fn get_maximum_rate(&self) -> Result<f64, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "MaximumRate")
     }
 
-    fn get_can_go_next(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanGoNext")
+    fn get_can_go_next(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanGoNext")
     }
 
-    fn get_can_go_previous(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanGoPrevious")
+    fn get_can_go_previous(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanGoPrevious")
     }
 
-    fn get_can_play(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanPlay")
+    fn get_can_play(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanPlay")
     }
 
-    fn get_can_pause(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanPause")
+    fn get_can_pause(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanPause")
     }
 
-    fn get_can_seek(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanSeek")
+    fn get_can_seek(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanSeek")
     }
 
-    fn get_can_control(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanControl")
+    fn get_can_control(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.Player", "CanControl")
     }
 
-    fn set_loop_status(&self, value: String) -> Result<(), Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "LoopStatus", value)
+    fn set_loop_status(&self, value: String) -> Result<(), dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "LoopStatus", value)
     }
 
-    fn set_rate(&self, value: f64) -> Result<(), Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "Rate", value)
+    fn set_rate(&self, value: f64) -> Result<(), dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "Rate", value)
     }
 
-    fn set_shuffle(&self, value: bool) -> Result<(), Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "Shuffle", value)
+    fn set_shuffle(&self, value: bool) -> Result<(), dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "Shuffle", value)
     }
 
-    fn set_volume(&self, value: f64) -> Result<(), Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "Volume", value)
+    fn set_volume(&self, value: f64) -> Result<(), dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::set(&self, "org.mpris.MediaPlayer2.Player", "Volume", value)
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct OrgMprisMediaPlayer2PlayerSeeked {
     pub position: i64,
 }
 
-impl dbus::SignalArgs for OrgMprisMediaPlayer2PlayerSeeked {
-    const NAME: &'static str = "Seeked";
-    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.Player";
+impl arg::AppendAll for OrgMprisMediaPlayer2PlayerSeeked {
     fn append(&self, i: &mut arg::IterAppend) {
         arg::RefArg::append(&self.position, i);
     }
-    fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.position = i.read()?;
-        Ok(())
+}
+
+impl arg::ReadAll for OrgMprisMediaPlayer2PlayerSeeked {
+    fn read(i: &mut arg::Iter) -> Result<Self, arg::TypeMismatchError> {
+        Ok(OrgMprisMediaPlayer2PlayerSeeked {
+            position: i.read()?,
+        })
     }
+}
+
+impl dbus::message::SignalArgs for OrgMprisMediaPlayer2PlayerSeeked {
+    const NAME: &'static str = "Seeked";
+    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.Player";
 }

--- a/src/generated/media_player_tracklist.rs
+++ b/src/generated/media_player_tracklist.rs
@@ -13,142 +13,146 @@
 
 use dbus as dbus;
 use dbus::arg;
+use dbus::ffidisp;
 
 pub trait OrgMprisMediaPlayer2TrackList {
-    type Err;
-    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>>, Self::Err>;
-    fn add_track(&self, uri: &str, after_track: dbus::Path, set_as_current: bool) -> Result<(), Self::Err>;
-    fn remove_track(&self, track_id: dbus::Path) -> Result<(), Self::Err>;
-    fn go_to(&self, track_id: dbus::Path) -> Result<(), Self::Err>;
-    fn get_tracks(&self) -> Result<Vec<dbus::Path<'static>>, Self::Err>;
-    fn get_can_edit_tracks(&self) -> Result<bool, Self::Err>;
+    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>>, dbus::Error>;
+    fn add_track(&self, uri: &str, after_track: dbus::Path, set_as_current: bool) -> Result<(), dbus::Error>;
+    fn remove_track(&self, track_id: dbus::Path) -> Result<(), dbus::Error>;
+    fn go_to(&self, track_id: dbus::Path) -> Result<(), dbus::Error>;
+    fn get_tracks(&self) -> Result<Vec<dbus::Path<'static>>, dbus::Error>;
+    fn get_can_edit_tracks(&self) -> Result<bool, dbus::Error>;
 }
 
-impl<'a, C: ::std::ops::Deref<Target=dbus::Connection>> OrgMprisMediaPlayer2TrackList for dbus::ConnPath<'a, C> {
-    type Err = dbus::Error;
+impl<'a, C: ::std::ops::Deref<Target=ffidisp::Connection>> OrgMprisMediaPlayer2TrackList for ffidisp::ConnPath<'a, C> {
 
-    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>>, Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"GetTracksMetadata".into(), |msg| {
-            let mut i = arg::IterAppend::new(msg);
-            i.append(track_ids);
-        })?;
-        m.as_result()?;
-        let mut i = m.iter_init();
-        let metadata: Vec<::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>> = i.read()?;
-        Ok(metadata)
+    fn get_tracks_metadata(&self, track_ids: Vec<dbus::Path>) -> Result<Vec<::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>>, dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.TrackList", "GetTracksMetadata", (track_ids, ))
+            .and_then(|r: (Vec<::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>>,)| Ok(r.0))
     }
 
-    fn add_track(&self, uri: &str, after_track: dbus::Path, set_as_current: bool) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"AddTrack".into(), |msg| {
-            let mut i = arg::IterAppend::new(msg);
-            i.append(uri);
-            i.append(after_track);
-            i.append(set_as_current);
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn add_track(&self, uri: &str, after_track: dbus::Path, set_as_current: bool) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.TrackList", "AddTrack", (uri, after_track, set_as_current, ))
     }
 
-    fn remove_track(&self, track_id: dbus::Path) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"RemoveTrack".into(), |msg| {
-            let mut i = arg::IterAppend::new(msg);
-            i.append(track_id);
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn remove_track(&self, track_id: dbus::Path) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.TrackList", "RemoveTrack", (track_id, ))
     }
 
-    fn go_to(&self, track_id: dbus::Path) -> Result<(), Self::Err> {
-        let mut m = self.method_call_with_args(&"org.mpris.MediaPlayer2.TrackList".into(), &"GoTo".into(), |msg| {
-            let mut i = arg::IterAppend::new(msg);
-            i.append(track_id);
-        })?;
-        m.as_result()?;
-        Ok(())
+    fn go_to(&self, track_id: dbus::Path) -> Result<(), dbus::Error> {
+        self.method_call("org.mpris.MediaPlayer2.TrackList", "GoTo", (track_id, ))
     }
 
-    fn get_tracks(&self) -> Result<Vec<dbus::Path<'static>>, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.TrackList", "Tracks")
+    fn get_tracks(&self) -> Result<Vec<dbus::Path<'static>>, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.TrackList", "Tracks")
     }
 
-    fn get_can_edit_tracks(&self) -> Result<bool, Self::Err> {
-        <Self as dbus::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.TrackList", "CanEditTracks")
+    fn get_can_edit_tracks(&self) -> Result<bool, dbus::Error> {
+        <Self as ffidisp::stdintf::org_freedesktop_dbus::Properties>::get(&self, "org.mpris.MediaPlayer2.TrackList", "CanEditTracks")
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct OrgMprisMediaPlayer2TrackListTrackListReplaced {
     pub tracks: Vec<dbus::Path<'static>>,
     pub current_track: dbus::Path<'static>,
 }
 
-impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackListReplaced {
-    const NAME: &'static str = "TrackListReplaced";
-    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
+impl arg::AppendAll for OrgMprisMediaPlayer2TrackListTrackListReplaced {
     fn append(&self, i: &mut arg::IterAppend) {
         arg::RefArg::append(&self.tracks, i);
         arg::RefArg::append(&self.current_track, i);
     }
-    fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.tracks = i.read()?;
-        self.current_track = i.read()?;
-        Ok(())
+}
+
+impl arg::ReadAll for OrgMprisMediaPlayer2TrackListTrackListReplaced {
+    fn read(i: &mut arg::Iter) -> Result<Self, arg::TypeMismatchError> {
+        Ok(OrgMprisMediaPlayer2TrackListTrackListReplaced {
+            tracks: i.read()?,
+            current_track: i.read()?,
+        })
     }
 }
 
-#[derive(Debug, Default)]
+impl dbus::message::SignalArgs for OrgMprisMediaPlayer2TrackListTrackListReplaced {
+    const NAME: &'static str = "TrackListReplaced";
+    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
+}
+
+#[derive(Debug)]
 pub struct OrgMprisMediaPlayer2TrackListTrackAdded {
-    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>,
+    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>,
     pub after_track: dbus::Path<'static>,
 }
 
-impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackAdded {
-    const NAME: &'static str = "TrackAdded";
-    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
+impl arg::AppendAll for OrgMprisMediaPlayer2TrackListTrackAdded {
     fn append(&self, i: &mut arg::IterAppend) {
         arg::RefArg::append(&self.metadata, i);
         arg::RefArg::append(&self.after_track, i);
     }
-    fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.metadata = i.read()?;
-        self.after_track = i.read()?;
-        Ok(())
+}
+
+impl arg::ReadAll for OrgMprisMediaPlayer2TrackListTrackAdded {
+    fn read(i: &mut arg::Iter) -> Result<Self, arg::TypeMismatchError> {
+        Ok(OrgMprisMediaPlayer2TrackListTrackAdded {
+            metadata: i.read()?,
+            after_track: i.read()?,
+        })
     }
 }
 
-#[derive(Debug, Default)]
+impl dbus::message::SignalArgs for OrgMprisMediaPlayer2TrackListTrackAdded {
+    const NAME: &'static str = "TrackAdded";
+    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
+}
+
+#[derive(Debug)]
 pub struct OrgMprisMediaPlayer2TrackListTrackRemoved {
     pub track_id: dbus::Path<'static>,
 }
 
-impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackRemoved {
-    const NAME: &'static str = "TrackRemoved";
-    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
+impl arg::AppendAll for OrgMprisMediaPlayer2TrackListTrackRemoved {
     fn append(&self, i: &mut arg::IterAppend) {
         arg::RefArg::append(&self.track_id, i);
     }
-    fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.track_id = i.read()?;
-        Ok(())
+}
+
+impl arg::ReadAll for OrgMprisMediaPlayer2TrackListTrackRemoved {
+    fn read(i: &mut arg::Iter) -> Result<Self, arg::TypeMismatchError> {
+        Ok(OrgMprisMediaPlayer2TrackListTrackRemoved {
+            track_id: i.read()?,
+        })
     }
 }
 
-#[derive(Debug, Default)]
-pub struct OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
-    pub track_id: dbus::Path<'static>,
-    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>,
+impl dbus::message::SignalArgs for OrgMprisMediaPlayer2TrackListTrackRemoved {
+    const NAME: &'static str = "TrackRemoved";
+    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
 }
 
-impl dbus::SignalArgs for OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
-    const NAME: &'static str = "TrackMetadataChanged";
-    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
+#[derive(Debug)]
+pub struct OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
+    pub track_id: dbus::Path<'static>,
+    pub metadata: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>,
+}
+
+impl arg::AppendAll for OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
     fn append(&self, i: &mut arg::IterAppend) {
         arg::RefArg::append(&self.track_id, i);
         arg::RefArg::append(&self.metadata, i);
     }
-    fn get(&mut self, i: &mut arg::Iter) -> Result<(), arg::TypeMismatchError> {
-        self.track_id = i.read()?;
-        self.metadata = i.read()?;
-        Ok(())
+}
+
+impl arg::ReadAll for OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
+    fn read(i: &mut arg::Iter) -> Result<Self, arg::TypeMismatchError> {
+        Ok(OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
+            track_id: i.read()?,
+            metadata: i.read()?,
+        })
     }
+}
+
+impl dbus::message::SignalArgs for OrgMprisMediaPlayer2TrackListTrackMetadataChanged {
+    const NAME: &'static str = "TrackMetadataChanged";
+    const INTERFACE: &'static str = "org.mpris.MediaPlayer2.TrackList";
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod pooled_connection;
 mod progress;
 mod track_list;
 
-pub use crate::event::{Event, EventError};
+pub use crate::event::{Event, EventError, PlayerEvents};
 pub use crate::find::{FindingError, PlayerFinder};
 pub use crate::metadata::{Metadata, Value as MetadataValue, ValueKind as MetadataValueKind};
 pub use crate::player::Player;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,
+    unreachable_pub,
     unstable_features,
     unused_import_braces,
     unused_qualifications
@@ -50,6 +51,8 @@ extern crate from_variants;
 extern crate dbus;
 
 mod extensions;
+
+#[allow(unreachable_pub)]
 mod generated;
 
 mod event;
@@ -62,7 +65,9 @@ mod track_list;
 
 pub use crate::event::{Event, EventError, PlayerEvents};
 pub use crate::find::{FindingError, PlayerFinder};
-pub use crate::metadata::{Metadata, Value as MetadataValue, ValueKind as MetadataValueKind};
+pub use crate::metadata::Metadata;
+pub use crate::metadata::ValueKind as MetadataValueKind;
+pub use crate::metadata::Value as MetadataValue;
 pub use crate::player::Player;
 pub use crate::progress::{Progress, ProgressError, ProgressTick, ProgressTracker};
 pub use crate::track_list::{TrackID, TrackList, TrackListError};

--- a/src/metadata/value.rs
+++ b/src/metadata/value.rs
@@ -348,7 +348,6 @@ impl dbus::arg::Arg for Value {
 
 impl<'a> dbus::arg::Get<'a> for Value {
     fn get(i: &mut dbus::arg::Iter) -> Option<Self> {
-        use dbus::arg::ArgType;
 
         let arg_type = i.arg_type();
         // Trying to calculate signature of an invalid arg will panic, so abort early.
@@ -387,7 +386,8 @@ impl<'a> dbus::arg::Get<'a> for Value {
 mod tests {
     use super::*;
     use dbus::arg::{Append, RefArg, Variant};
-    use dbus::{BusType, Connection, ConnectionItem, Message};
+    use dbus::ffidisp::{BusType, Connection, ConnectionItem};
+    use dbus::Message;
 
     fn send_values_over_dbus<F>(appender: F) -> Message
     where
@@ -495,7 +495,7 @@ mod tests {
 
     #[test]
     fn it_supports_arrays_of_variants() {
-        let input: Vec<Variant<Box<RefArg>>> = vec![
+        let input: Vec<Variant<Box<dyn RefArg>>> = vec![
             Variant(Box::new(String::from("World"))),
             Variant(Box::new(42u8)),
         ];
@@ -524,7 +524,7 @@ mod tests {
 
     #[test]
     fn it_supports_maps_of_variants() {
-        let mut input: HashMap<String, Variant<Box<RefArg>>> = HashMap::new();
+        let mut input: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
         input.insert(
             String::from("receiver"),
             Variant(Box::new(String::from("World"))),

--- a/src/player.rs
+++ b/src/player.rs
@@ -21,7 +21,7 @@ pub(crate) const MPRIS2_PREFIX: &str = "org.mpris.MediaPlayer2.";
 pub(crate) const MPRIS2_PATH: &str = "/org/mpris/MediaPlayer2";
 
 /// When D-Bus connection is managed for you, use this timeout while communicating with a Player.
-pub const DEFAULT_TIMEOUT_MS: i32 = 500; // ms
+pub(crate) const DEFAULT_TIMEOUT_MS: i32 = 500; // ms
 
 /// A MPRIS-compatible player.
 ///

--- a/src/player.rs
+++ b/src/player.rs
@@ -5,7 +5,8 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::time::Duration;
 
-use dbus::{BusName, ConnPath, Connection, Path};
+use dbus::ffidisp::{ConnPath, Connection};
+use dbus::strings::{BusName, Path};
 
 use super::{DBusError, LoopStatus, MetadataValue, PlaybackStatus, TrackID, TrackList};
 use crate::event::PlayerEvents;
@@ -272,7 +273,7 @@ impl<'a> Player<'a> {
     ///
     /// See `Metadata` for more information about what is included here.
     pub fn get_metadata(&self) -> Result<Metadata, DBusError> {
-        use dbus::stdintf::org_freedesktop_dbus::Properties;
+        use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
 
         let connection_path = self.connection_path();
 
@@ -292,7 +293,7 @@ impl<'a> Player<'a> {
     ///
     /// See `checked_get_track_list` to automatically detect players not supporting track lists.
     pub fn get_track_list(&self) -> Result<TrackList, DBusError> {
-        use dbus::stdintf::org_freedesktop_dbus::Properties;
+        use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
 
         let connection_path = self.connection_path();
 
@@ -329,8 +330,7 @@ impl<'a> Player<'a> {
     /// See: [MPRIS2 specification about
     /// `CanEditTracks`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Property:CanEditTracks).
     pub fn can_edit_tracks(&self) -> Result<bool, DBusError> {
-        use dbus::stdintf::org_freedesktop_dbus::Properties;
-
+        use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
         let connection_path = self.connection_path();
 
         Properties::get::<bool>(
@@ -619,11 +619,7 @@ impl<'a> Player<'a> {
     /// Requires the player to implement the `TrackList` interface.
     ///
     /// See: [MPRIS2 specification about `AddTrack`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:AddTrack)
-    pub fn add_track_at_start(
-        &self,
-        uri: &str,
-        set_as_current: bool,
-    ) -> Result<(), DBusError> {
+    pub fn add_track_at_start(&self, uri: &str, set_as_current: bool) -> Result<(), DBusError> {
         use crate::generated::OrgMprisMediaPlayer2TrackList;
 
         self.connection_path()
@@ -1057,7 +1053,7 @@ fn has_tracklist_interface(connection: ConnPath<&Connection>) -> Result<bool, DB
     //
     // It's probably accurate enough.
 
-    use dbus::stdintf::OrgFreedesktopDBusIntrospectable;
+    use dbus::ffidisp::stdintf::OrgFreedesktopDBusIntrospectable;
     let xml: String = connection.introspect()?;
     Ok(xml.contains("org.mpris.MediaPlayer2.TrackList"))
 }

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -2,7 +2,9 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use dbus::{BusName, ConnPath, Connection, Message, Path};
+use dbus::ffidisp::{ConnPath, Connection};
+use dbus::strings::{BusName, Path};
+use dbus::Message;
 
 use crate::extensions::DurationExtensions;
 use crate::metadata::{Metadata, Value};

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -156,7 +156,7 @@ impl PooledConnection {
     /// to the generated MprisEvent, if applicable.
     fn process_message(&self, message: MprisMessage) {
         let mut events = match self.events.try_borrow_mut() {
-            Ok(mut val) => val,
+            Ok(val) => val,
             Err(_) => {
                 // Drop the message. This is a better evil than triggering a panic inside a library
                 // like this.

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -280,7 +280,7 @@ impl TrackList {
                 self.ids[index] = new_id.to_owned();
                 self.change_metadata(|cache| cache.insert(new_id.to_owned(), new_metadata));
 
-                return Some(new_id.to_owned());
+                return Some(new_id);
             }
         }
 


### PR DESCRIPTION
PlayerEvents was not actually re-exported at the crate root, so `Player::events` couldn't actually be used. I fixed that and added the `unreachable_pub` lint to (hopefully) catch similar issues in the future, but it's worth noting that the lint has a bug right now for certain use cases; see [rust issue #64762](https://github.com/rust-lang/rust/issues/64762). 
I also updated dbus while I was at it, which required a bunch of import changes since a lot of the previous api got moved to `dbus::ffidisp`. 