### PR TITLE
Fix Connection::events with non-Shuffle returning Err

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -324,7 +324,7 @@ impl Progress {
         Ok(Progress {
             metadata: player.get_metadata()?,
             playback_status: player.get_playback_status()?,
-            shuffle: player.get_shuffle()?,
+            shuffle: player.checked_get_shuffle()?.unwrap_or(false),
             loop_status: player.get_loop_status()?,
             rate: player.get_playback_rate()?,
             position: player.get_position()?,


### PR DESCRIPTION
When a Player does not support the "Shuffle" property, which the MPRIS
specification declares as optional, Player::events will Error. This is
caused by the PlayerEvents internally constructing a Progress tracker.
This Progress tracker then queries the shuffle state, resulting in said
error. My patch fixes this by adding the following functions to the
Player impl:
* Player::can_shuffle()
* Player::checked_get_shuffle()

It further modifies Player::checked_set_shuffle() to also check for the
existence of "Shuffle". The Progress impl is changed to assume a player
is not shuffling, if the property is not present. It could also allow
keeping track of the can_shuffle state, however that would be a breaking
change (the Event enum would have to change in some way), and i'd advise
against that.