### PR TITLE
Failsafes for unsupported properties in some players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `Player::bus_name_player_name_part` - [Koen Bolhuis
   (InputUsername)](https://github.com/InputUsername)
 * `Metadata::as_hashmap(&self)` which returns a simple borrowed hashmap.
+* More `Player::has_*`, `Player::can_*`, and
+  `Player::checked_*` methods - [Harrison Thorne
+  (harrisonthorne)][harrisonthorne]
+  * `Player::has_volume`, `Player::checked_get_volume`,
+    `Player::checked_set_volume` 
+  * `Player::has_position`,
+    `Player::checked_get_position`,
+    `Player::checked_set_position`
+  * `Player::has_playback_rate`,
+    `Player::checked_get_playback_rate`,
+    `Player::checked_set_playback_rate` 
+  * `Player::can_loop`, `Player::checked_get_loop_status`
 
 ## Changed
 
 * `Player::checked_set_shuffle` also checks `::can_shuffle`. - [Stephan
   Henrichs (Kilobyte22)][Kilobyte22]
+* `Player::checked_set_loop_status` also checks `::can_loop` - 
+  [Harrison Thorne (harrisonthorne)][harrisonthorne]
+* `Progress` default values to used `checked_get_*`
+  functions - [Harrison Thorne
+  (harrisonthorne)][harrisonthorne]
+
 
 ## [v2.0.0-rc2] - 2020-02-15
 
@@ -178,3 +196,4 @@ versions.
 [v1.0.0]: https://github.com/Mange/mpris-rs/compare/v0.1.0...v1.0.0
 
 [Kilobyte22]: https://github.com/Kilobyte22
+[harrisonthorne]: https://github.com/harrisonthorne

--- a/examples/capabilities.rs
+++ b/examples/capabilities.rs
@@ -59,11 +59,16 @@ fn print_capabilities_for_player(player: Player) -> Result<(), Error> {
     print_value("CanControl", player.can_control());
     print_value("CanGoNext", player.can_go_next());
     print_value("CanGoPrevious", player.can_go_previous());
+    print_value("CanLoop", player.can_loop());
     print_value("CanPause", player.can_pause());
     print_value("CanPlay", player.can_play());
     print_value("CanSeek", player.can_seek());
     print_value("CanSetPaybackRate", player.can_set_playback_rate());
+    print_value("CanShuffle", player.can_shuffle());
     print_value("CanStop", player.can_stop());
+    print_value("HasPlaybackRate", player.has_playback_rate());
+    print_value("HasPosition", player.has_position());
+    print_value("HasVolume", player.has_volume());
 
     print_value("Rate", player.get_playback_rate());
     print_value("MaximumRate", player.get_maximum_playback_rate());

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -327,7 +327,7 @@ impl Progress {
             shuffle: player.checked_get_shuffle()?.unwrap_or(false),
             loop_status: player.checked_get_loop_status()?.unwrap_or(LoopStatus::None),
             rate: player.checked_get_playback_rate()?.unwrap_or(1.0),
-            position: player.get_position()?,
+            position: player.checked_get_position()?.unwrap_or_else(|| Duration::new(0, 0)),
             current_volume: player.get_volume()?,
             instant: Instant::now(),
         })

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -325,7 +325,7 @@ impl Progress {
             metadata: player.get_metadata()?,
             playback_status: player.get_playback_status()?,
             shuffle: player.checked_get_shuffle()?.unwrap_or(false),
-            loop_status: player.get_loop_status()?,
+            loop_status: player.checked_get_loop_status()?.unwrap_or(LoopStatus::None),
             rate: player.get_playback_rate()?,
             position: player.get_position()?,
             current_volume: player.get_volume()?,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -328,7 +328,7 @@ impl Progress {
             loop_status: player.checked_get_loop_status()?.unwrap_or(LoopStatus::None),
             rate: player.checked_get_playback_rate()?.unwrap_or(1.0),
             position: player.checked_get_position()?.unwrap_or_else(|| Duration::new(0, 0)),
-            current_volume: player.get_volume()?,
+            current_volume: player.checked_get_volume()?.unwrap_or(1.0),
             instant: Instant::now(),
         })
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -326,7 +326,7 @@ impl Progress {
             playback_status: player.get_playback_status()?,
             shuffle: player.checked_get_shuffle()?.unwrap_or(false),
             loop_status: player.checked_get_loop_status()?.unwrap_or(LoopStatus::None),
-            rate: player.get_playback_rate()?,
+            rate: player.checked_get_playback_rate()?.unwrap_or(1.0),
             position: player.get_position()?,
             current_volume: player.get_volume()?,
             instant: Instant::now(),


### PR DESCRIPTION
Following in the footsteps of #50, this PR adds quite a set of functions to assist with handling players that don't support Rate, Volume, Position, or LoopStatus.

Firefox doesn't seem to support these properties, so I found it necessary to add these failsafes in order for the `Player::events()` function to work.