### PR TITLE
Fix events not being added when listening to a stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [Stephan Henrichs (Kilobyte22)][Kilobyte22]
 * Error on progress tracker for players that do not support shuffling. -
   [Stephan Henrichs (Kilobyte22)][Kilobyte22]
+* Events not added for streams - [Kanjirito][Kanjirito]
 
 ## Added
 
@@ -46,6 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   (harrisonthorne)][harrisonthorne]
 * `Progress` default values uses `checked_get_*` functions - [Harrison
   Thorne (harrisonthorne)][harrisonthorne]
+* Documentation was made easier to navigate - [Kanjirito][Kanjirito]
 
 
 ## [v2.0.0-rc2] - 2020-02-15
@@ -196,3 +198,4 @@ versions.
 
 [Kilobyte22]: https://github.com/Kilobyte22
 [harrisonthorne]: https://github.com/harrisonthorne
+[Kanjirito]: https://github.com/Kanjirito

--- a/src/event.rs
+++ b/src/event.rs
@@ -251,9 +251,13 @@ impl<'a> PlayerEvents<'a> {
         let old_metadata = self.last_progress.metadata();
 
         // As a workaround for Players not setting a valid track ID, we also check against the URL
+        // Title and artists are checked to detect changes for streams (radios) because track ID and URL don't change.
+        // Title is checked first because most radios set title to `Artist - Title` and have the station name in artists.
 
         if old_metadata.track_id() != new_metadata.track_id()
             || old_metadata.url() != new_metadata.url()
+            || old_metadata.title() != new_metadata.title()
+            || old_metadata.artists() != new_metadata.artists()
         {
             self.buffer.push(Event::TrackChanged(new_metadata.clone()));
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,40 +5,40 @@ use super::{
 use crate::pooled_connection::MprisEvent;
 use failure::Fail;
 
-/// Represents a change in Player state.
+/// Represents a change in [`Player`] state.
 ///
 /// Note that this does not include position changes (seeking in a track or normal progress of time
 /// for playing media).
 #[derive(Debug)]
 pub enum Event {
-    /// Player was shut down / quit.
+    /// [`Player`] was shut down / quit.
     PlayerShutDown,
 
-    /// Player was paused.
+    /// [`Player`] was paused.
     Paused,
 
-    /// Player started playing media.
+    /// [`Player`] started playing media.
     Playing,
 
-    /// Player was stopped.
+    /// [`Player`] was stopped.
     Stopped,
 
-    /// Loop status of player was changed. New loop status is provided.
+    /// Loop status of [`Player`] was changed. New [`LoopStatus`] is provided.
     LoopingChanged(LoopStatus),
 
-    /// Shuffle status of player was changed. New shuffle status is provided.
+    /// Shuffle status of [`Player`] was changed. New shuffle status is provided.
     ShuffleToggled(bool),
 
-    /// Player's volume was changed. The new volume is provided.
+    /// [`Player`]'s volume was changed. The new volume is provided.
     VolumeChanged(f64),
 
-    /// Player's playback rate was changed. New playback rate is provided.
+    /// [`Player`]'s playback rate was changed. New playback rate is provided.
     PlaybackRateChanged(f64),
 
-    /// Player's track changed. Metadata of the new track is provided.
+    /// [`Player`]'s track changed. [`Metadata`] of the new track is provided.
     TrackChanged(Metadata),
 
-    /// Player seeked (changed position in the current track).
+    /// [`Player`] seeked (changed position in the current track).
     ///
     /// This will only be emitted when the player in question emits this signal. Some players do
     /// not support this signal. If you want to accurately detect seeking, you'll have to query
@@ -48,13 +48,13 @@ pub enum Event {
         position_in_us: u64,
     },
 
-    /// A new track was added to the TrackList.
+    /// A new track was added to the [`TrackList`].
     TrackAdded(TrackID),
 
-    /// A track was removed from the TrackList.
+    /// A track was removed from the [`TrackList`].
     TrackRemoved(TrackID),
 
-    /// A track on the TrackList had its metadata changed.
+    /// A track on the [`TrackList`] had its metadata changed.
     ///
     /// This could also mean that a entry on the playlist completely changed; including the ID.
     TrackMetadataChanged {
@@ -82,25 +82,25 @@ pub enum Event {
 /// Errors that can occur while processing event streams.
 #[derive(Debug, Fail)]
 pub enum EventError {
-    /// Something went wrong with the D-Bus communication. See the `DBusError` type.
+    /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
     #[fail(display = "D-Bus communication failed")]
     DBusError(#[cause] DBusError),
 
-    /// Something went wrong with the track list. See the `TrackListError` type.
+    /// Something went wrong with the track list. See the [`TrackListError`] type.
     #[fail(display = "TrackList could not be refreshed")]
     TrackListError(#[cause] TrackListError),
 }
 
-/// Iterator that blocks forever until the player has an event.
+/// Iterator that blocks forever until the player has an [`Event`].
 ///
 /// Iteration will stop if player stops running. If the player was running before this iterator
-/// blocks, one last `Event::PlayerShutDown` event will be emitted before stopping iteration.
+/// blocks, one last [`Event::PlayerShutDown`] event will be emitted before stopping iteration.
 ///
 /// If multiple events are found between processing D-Bus events then all of them will be iterated
 /// in rapid succession before processing more events.
 #[derive(Debug)]
 pub struct PlayerEvents<'a> {
-    /// Player to watch.
+    /// [`Player`] to watch.
     player: &'a Player<'a>,
 
     /// Queued up events found after the last signal.

--- a/src/find.rs
+++ b/src/find.rs
@@ -18,7 +18,7 @@ pub enum FindingError {
     #[fail(display = "No player found")]
     NoPlayerFound,
 
-    /// Finding failed due to an underlying D-Bus error.
+    /// Finding failed due to an underlying [`DBusError`].
     #[fail(display = "{}", _0)]
     DBusError(#[cause] DBusError),
 }
@@ -35,25 +35,25 @@ impl From<DBusError> for FindingError {
     }
 }
 
-/// Used to find `Player`s running on a D-Bus connection.
+/// Used to find [`Player`]s running on a D-Bus connection.
 #[derive(Debug)]
 pub struct PlayerFinder {
     connection: Rc<PooledConnection>,
 }
 
 impl PlayerFinder {
-    /// Creates a new `PlayerFinder` with a new default D-Bus connection.
+    /// Creates a new [`PlayerFinder`] with a new default D-Bus connection.
     ///
-    /// Use `for_connection` if you want to provide the D-Bus connection yourself.
+    /// Use [`for_connection`](Self::for_connection) if you want to provide the D-Bus connection yourself.
     pub fn new() -> Result<Self, DBusError> {
         Ok(PlayerFinder::for_connection(Connection::get_private(
             BusType::Session,
         )?))
     }
 
-    /// Create a new `PlayerFinder` with the given connection.
+    /// Create a new [`PlayerFinder`] with the given connection.
     ///
-    /// Use `new` if you want a new default connection rather than manually managing the D-Bus
+    /// Use [`new`](Self::new) if you want a new default connection rather than manually managing the D-Bus
     /// connection.
     pub fn for_connection(connection: Connection) -> Self {
         PlayerFinder {
@@ -61,7 +61,7 @@ impl PlayerFinder {
         }
     }
 
-    /// Find all available `Player`s in the connection.
+    /// Find all available [`Player`]s in the connection.
     pub fn find_all<'b>(&self) -> Result<Vec<Player<'b>>, FindingError> {
         self.all_player_buses()
             .map_err(FindingError::from)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! Some hints on how to use this library:
 //!
 //! 1. Look at the examples under `examples/`.
-//! 2. Look at the `PlayerFinder` struct.
+//! 2. Look at the [`PlayerFinder`] struct.
 //!
 
 use failure::Fail;
@@ -52,17 +52,26 @@ pub use crate::track_list::{TrackID, TrackList, TrackListError};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 #[allow(missing_docs)]
+/// The [`Player`]'s playback status
+///
+/// See: [MPRIS2 specification about `PlaybackStatus`][playback_status]
+///
+/// [playback_status]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Enum:Playback_Status
 pub enum PlaybackStatus {
+    /// A track is currently playing.
     Playing,
+    /// A track is currently paused.
     Paused,
+    /// There is no track currently playing.
     Stopped,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-/// A Player's looping status.
+/// A [`Player`]'s looping status.
 ///
-/// See: [MPRIS2 specification about
-/// `Loop_Status`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Enum:Loop_Status)
+/// See: [MPRIS2 specification about `Loop_Status`][loop_status]
+///
+/// [loop_status]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Enum:Loop_Status
 pub enum LoopStatus {
     /// The playback will stop when there are no more tracks to play
     None,
@@ -74,7 +83,7 @@ pub enum LoopStatus {
     Playlist,
 }
 
-/// `PlaybackStatus` had an invalid string value.
+/// [`PlaybackStatus`] had an invalid string value.
 #[derive(Fail, Debug)]
 #[fail(
     display = "PlaybackStatus must be one of Playing, Paused, Stopped, but was {}",
@@ -97,7 +106,7 @@ impl ::std::str::FromStr for PlaybackStatus {
     }
 }
 
-/// `LoopStatus` had an invalid string value.
+/// [`LoopStatus`] had an invalid string value.
 #[derive(Fail, Debug)]
 #[fail(
     display = "LoopStatus must be one of None, Track, Playlist, but was {}",
@@ -136,12 +145,12 @@ pub enum DBusError {
     #[fail(display = "D-Bus call failed: {}", _0)]
     TransportError(#[cause] dbus::Error),
 
-    /// Failed to parse an enum from a string value received from the player. This means that the
-    /// player replied with unexpected data.
+    /// Failed to parse an enum from a string value received from the [`Player`]. This means that the
+    /// [`Player`] replied with unexpected data.
     #[fail(display = "Failed to parse enum value: {}", _0)]
     EnumParseError(String),
 
-    /// A D-Bus method call did not pass arguments of the correct type. This means that the player
+    /// A D-Bus method call did not pass arguments of the correct type. This means that the [`Player`]
     /// replied with unexpected data.
     #[fail(display = "D-Bus call failed: {}", _0)]
     TypeMismatchError(#[cause] dbus::arg::TypeMismatchError),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,18 +5,20 @@ use super::TrackID;
 use std::collections::HashMap;
 use std::time::Duration;
 
-/// A structured representation of the `Player` metadata.
+/// A structured representation of the [`Player`](crate::player::Player) metadata.
 ///
-/// * [Read more about the MPRIS2 `Metadata_Map`
-/// type.](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Mapping:Metadata_Map)
-/// * [Read MPRIS v2 metadata guidelines](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/)
+/// * [Read more about the MPRIS2 `Metadata_Map` type.][metadata_map]
+/// * [Read MPRIS v2 metadata guidelines][metadata_guidelines]
+///
+/// [metadata_map]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Mapping:Metadata_Map
+/// [metadata_guidelines]: https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/
 #[derive(Debug, Default, Clone)]
 pub struct Metadata {
     values: HashMap<String, Value>,
 }
 
 impl Metadata {
-    /// Create a new `Metadata` struct with a given `track_id`.
+    /// Create a new [`Metadata`] struct with a given `track_id`.
     ///
     /// This is mostly useful for test fixtures and other places where you want to work with mock
     /// data.
@@ -51,7 +53,7 @@ impl Metadata {
 
     /// The track ID.
     ///
-    /// If the TrackID could not be parsed as a proper TrackID, `None` will be returned.
+    /// If the [`TrackID`] could not be parsed as a proper [`TrackID`], [`None`] will be returned.
     ///
     /// Based on `mpris:trackid`
     /// > A unique identity for this track within the context of an MPRIS object.
@@ -121,7 +123,7 @@ impl Metadata {
         }
     }
 
-    /// The duration of the track, as a `Duration`
+    /// The duration of the track, as a [`Duration`]
     ///
     /// Based on `mpris:length`.
     pub fn length(&self) -> Option<Duration> {
@@ -153,10 +155,10 @@ impl Metadata {
         self.get("xesam:url").and_then(Value::as_str)
     }
 
-    /// Returns an owned `HashMap` of borrowed values from this `Metadata`. Useful if you need a
-    /// mutable hash but don't have ownership of `Metadata` or want to consume it.
+    /// Returns an owned [`HashMap`] of borrowed values from this [`Metadata`]. Useful if you need a
+    /// mutable hash but don't have ownership of [`Metadata`] or want to consume it.
     ///
-    /// If you want to convert to a `HashMap`, use `Into::into` instead.
+    /// If you want to convert to a [`HashMap`], use [`Into::into`](std::convert::Into::into) instead.
     pub fn as_hashmap(&self) -> HashMap<&str, &Value> {
         self.iter().collect()
     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -25,8 +25,9 @@ pub(crate) const DEFAULT_TIMEOUT_MS: i32 = 500; // ms
 ///
 /// You can query this player about the currently playing media, or control it.
 ///
-/// **See:** [MPRIS2 MediaPlayer2.Player Specification][spec]
-/// [spec]: <https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html>
+/// **See:** [MPRIS2 MediaPlayer2.Player Specification][spec].
+/// 
+/// [spec]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
 #[derive(Debug)]
 pub struct Player<'a> {
     connection: Rc<PooledConnection>,
@@ -39,9 +40,9 @@ pub struct Player<'a> {
 }
 
 impl<'a> Player<'a> {
-    /// Create a new `Player` using a D-Bus connection and address information.
+    /// Create a new [`Player`] using a D-Bus connection and address information.
     ///
-    /// If no player is running on this bus name an `Err` will be returned.
+    /// If no player is running on this bus name an [`Err`] will be returned.
     pub fn new<B, P>(
         connection: Connection,
         bus_name: B,
@@ -102,7 +103,7 @@ impl<'a> Player<'a> {
     /// When querying D-Bus the call should not block longer than this, and will instead fail the
     /// query if no response has been received in this time.
     ///
-    /// You can change this using `set_dbus_timeout_ms`.
+    /// You can change this using [`set_dbus_timeout_ms`](Self::set_dbus_timeout_ms).
     pub fn dbus_timeout_ms(&self) -> i32 {
         self.timeout_ms
     }
@@ -120,7 +121,9 @@ impl<'a> Player<'a> {
     /// Returns the player name part of the player's D-Bus bus name.
     /// This is the part after "org.mpris.MediaPlayer2.", not including the instance part.
     ///
-    /// See: [MPRIS2 specification about bus names](https://specifications.freedesktop.org/mpris-spec/latest/#Bus-Name-Policy).
+    /// See: [MPRIS2 specification about bus names][bus_names].
+    ///
+    /// [bus_names]: https://specifications.freedesktop.org/mpris-spec/latest/#Bus-Name-Policy
     pub fn bus_name_player_name_part(&self) -> &str {
         self.bus_name()
             .as_cstr()
@@ -137,9 +140,11 @@ impl<'a> Player<'a> {
         &self.unique_name
     }
 
-    /// Returns the player's MPRIS `Identity`.
+    /// Returns the player's MPRIS [`Identity`][identity].
     ///
     /// This is usually the application's name, like `Spotify`.
+    ///
+    /// [identity]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:Identity
     pub fn identity(&self) -> &str {
         &self.identity
     }
@@ -151,16 +156,18 @@ impl<'a> Player<'a> {
 
     /// Returns the player's `DesktopEntry` property, if supported.
     ///
-    /// See: [MPRIS2 specification about
-    /// `DesktopEntry`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:DesktopEntry).
+    /// See: [MPRIS2 specification about `DesktopEntry`][desktop_entry].
+    ///
+    /// [desktop_entry]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:DesktopEntry
     pub fn get_desktop_entry(&self) -> Result<Option<String>, DBusError> {
         handle_optional_property(self.connection_path().get_desktop_entry())
     }
 
     /// Returns the player's `SupportedMimeTypes` property.
     ///
-    /// See: [MPRIS2 specification about
-    /// `SupportedMimeTypes`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:SupportedMimeTypes).
+    /// See: [MPRIS2 specification about `SupportedMimeTypes`][mime_types].
+    ///
+    /// [mime_types]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:SupportedMimeTypes
     pub fn get_supported_mime_types(&self) -> Result<Vec<String>, DBusError> {
         self.connection_path()
             .get_supported_mime_types()
@@ -169,8 +176,9 @@ impl<'a> Player<'a> {
 
     /// Returns the player's `SupportedUriSchemes` property.
     ///
-    /// See: [MPRIS2 specification about
-    /// `SupportedUriSchemes`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:SupportedUriSchemes).
+    /// See: [MPRIS2 specification about `SupportedUriSchemes`][schemes].
+    ///
+    /// [schemes]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:SupportedUriSchemes
     pub fn get_supported_uri_schemes(&self) -> Result<Vec<String>, DBusError> {
         self.connection_path()
             .get_supported_uri_schemes()
@@ -179,15 +187,16 @@ impl<'a> Player<'a> {
 
     /// Returns the player's `HasTrackList` property.
     ///
-    /// See: [MPRIS2 specification about
-    /// `HasTrackList`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:HasTrackList).
+    /// See: [MPRIS2 specification about `HasTrackList`][track_list].
+    ///
+    /// [track_list]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:HasTrackList
     pub fn get_has_track_list(&self) -> Result<bool, DBusError> {
         self.connection_path()
             .get_has_track_list()
             .map_err(|e| e.into())
     }
 
-    /// Returns the player's MPRIS `position` as a `Duration` since the start of the media.
+    /// Returns the player's MPRIS `position` as a [`Duration`] since the start of the media.
     pub fn get_position(&self) -> Result<Duration, DBusError> {
         self.get_position_in_microseconds()
             .map(Duration::from_micros_ext)
@@ -195,8 +204,8 @@ impl<'a> Player<'a> {
 
     /// Gets the "Position" setting, if the player indicates that it supports it.
     ///
-    /// Return [[Some]] containing the current value of the position. If the setting is not
-    /// supported, return [[None]]
+    /// Return [`Some`] containing the current value of the position. If the setting is not
+    /// supported, return [`None`]
     pub fn checked_get_position(&self) -> Result<Option<Duration>, DBusError> {
         if self.has_position()? {
             Ok(Some(self.get_position()?))
@@ -214,15 +223,17 @@ impl<'a> Player<'a> {
             .map_err(|e| e.into())
     }
 
-    /// Sets the position of the current track to the given position (as a `Duration`).
+    /// Sets the position of the current track to the given position (as a [`Duration`]).
     ///
-    /// Current `TrackID` must be provided to avoid race conditions with the player, in case it
+    /// Current [`TrackID`] must be provided to avoid race conditions with the player, in case it
     /// changes tracks while the signal is being sent.
     ///
-    /// **Note:** There is currently no good way to retrieve the current `TrackID` through the
+    /// **Note:** There is currently no good way to retrieve the current [`TrackID`] through the
     /// `mpris` library. You will have to manually retrieve it through D-Bus until implemented.
     ///
-    /// See: [MPRIS2 specification about `SetPosition`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:SetPosition)
+    /// See: [MPRIS2 specification about `SetPosition`][set_position].
+    ///
+    /// [set_position]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:SetPosition
     pub fn set_position(&self, track_id: TrackID, position: &Duration) -> Result<(), DBusError> {
         self.set_position_in_microseconds(track_id, DurationExtensions::as_micros(position))
     }
@@ -232,8 +243,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Position`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Position)
+    /// See: [MPRIS2 specification about `Position`][position].
+    ///
+    /// [position]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Position
     pub fn checked_set_position(
         &self,
         track_id: TrackID,
@@ -250,13 +262,15 @@ impl<'a> Player<'a> {
 
     /// Sets the position of the current track to the given position (in microseconds).
     ///
-    /// Current `TrackID` must be provided to avoid race conditions with the player, in case it
+    /// Current [`TrackID`] must be provided to avoid race conditions with the player, in case it
     /// changes tracks while the signal is being sent.
     ///
-    /// **Note:** There is currently no good way to retrieve the current `TrackID` through the
+    /// **Note:** There is currently no good way to retrieve the current [`TrackID`] through the
     /// `mpris` library. You will have to manually retrieve it through D-Bus until implemented.
     ///
-    /// See: [MPRIS2 specification about `SetPosition`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:SetPosition)
+    /// See: [MPRIS2 specification about `SetPosition`][set_position].
+    ///
+    /// [set_position]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:SetPosition
     pub fn set_position_in_microseconds(
         &self,
         track_id: TrackID,
@@ -276,8 +290,8 @@ impl<'a> Player<'a> {
 
     /// Gets the "Rate" setting, if the player indicates that it supports it.
     ///
-    /// Returns [[Some]] containing the current value of the rate setting. If the setting is not
-    /// supported, returns [[None]]
+    /// Returns [`Some`] containing the current value of the rate setting. If the setting is not
+    /// supported, returns [`None`]
     pub fn checked_get_playback_rate(&self) -> Result<Option<f64>, DBusError> {
         if self.has_playback_rate()? {
             Ok(Some(self.get_playback_rate()?))
@@ -291,12 +305,14 @@ impl<'a> Player<'a> {
     /// 1.0 would mean normal rate, while 2.0 would mean twice the playback speed.
     ///
     /// It is not allowed to try to set playback rate to a value outside of the supported range.
-    /// `Player::get_valid_playback_rate_range` returns a `Range<f64>` that encodes the maximum and
+    /// [`get_valid_playback_rate_range`](Self::get_valid_playback_rate_range) returns a [`Range<f64>`] that encodes the maximum and
     /// minimum values.
     ///
-    /// You must not set rate to 0.0; instead call `Player::pause`.
+    /// You must not set rate to 0.0; instead call [`pause`](Self::pause).
     ///
-    /// See: [MPRIS2 specification about `Rate`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Rate)
+    /// See: [MPRIS2 specification about `Rate`][rate].
+    ///
+    /// [rate]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Rate
     pub fn set_playback_rate(&self, rate: f64) -> Result<(), DBusError> {
         self.connection_path().set_rate(rate).map_err(|e| e.into())
     }
@@ -306,8 +322,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Rate`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Rate)
+    /// See: [MPRIS2 specification about `Rate`][rate].
+    ///
+    /// [rate]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Rate
     pub fn checked_set_playback_rate(&self, rate: f64) -> Result<bool, DBusError> {
         if self.can_control()? && self.has_playback_rate()? {
             self.set_playback_rate(rate)
@@ -320,7 +337,9 @@ impl<'a> Player<'a> {
 
     /// Gets the minimum allowed value for playback rate.
     ///
-    /// See: [MPRIS2 specification about `MinimumRate`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:MinimumRate)
+    /// See: [MPRIS2 specification about `MinimumRate`][min_rate].
+    ///
+    /// [min_rate]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:MinimumRate
     pub fn get_minimum_playback_rate(&self) -> Result<f64, DBusError> {
         self.connection_path()
             .get_minimum_rate()
@@ -329,7 +348,9 @@ impl<'a> Player<'a> {
 
     /// Gets the maximum allowed value for playback rate.
     ///
-    /// See: [MPRIS2 specification about `MaximumRate`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:MaximumRate)
+    /// See: [MPRIS2 specification about `MaximumRate`][max_rate].
+    ///
+    /// [max_rate]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:MaximumRate
     pub fn get_maximum_playback_rate(&self) -> Result<f64, DBusError> {
         self.connection_path()
             .get_maximum_rate()
@@ -338,7 +359,8 @@ impl<'a> Player<'a> {
 
     /// Gets the minimum-maximum allowed value range for playback rate.
     ///
-    /// See: `get_minimum_playback_rate` and `get_maximum_playback_rate`.
+    /// See: [`get_minimum_playback_rate`](Self::get_minimum_playback_rate)
+    /// and [`get_maximum_playback_rate`](Self::get_maximum_playback_rate).
     pub fn get_valid_playback_rate_range(&self) -> Result<Range<f64>, DBusError> {
         self.get_minimum_playback_rate()
             .and_then(|min| self.get_maximum_playback_rate().map(|max| min..max))
@@ -346,7 +368,7 @@ impl<'a> Player<'a> {
 
     /// Query the player for current metadata.
     ///
-    /// See `Metadata` for more information about what is included here.
+    /// See [`Metadata`] for more information about what is included here.
     pub fn get_metadata(&self) -> Result<Metadata, DBusError> {
         use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
 
@@ -364,9 +386,9 @@ impl<'a> Player<'a> {
     /// Query the player for the current tracklist.
     ///
     /// **Note:** It's more expensive to rebuild this each time rather than trying to keep the same
-    /// `TrackList` updated. See `TrackList::reload`.
+    /// [`TrackList`] updated. See [`TrackList::reload`].
     ///
-    /// See `checked_get_track_list` to automatically detect players not supporting track lists.
+    /// See [`checked_get_track_list`](Self::checked_get_track_list) to automatically detect players not supporting track lists.
     pub fn get_track_list(&self) -> Result<TrackList, DBusError> {
         use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
 
@@ -384,10 +406,10 @@ impl<'a> Player<'a> {
     /// Query the player for the current tracklist.
     ///
     /// **Note:** It's more expensive to rebuild this each time rather than trying to keep the same
-    /// `TrackList` updated. See `TrackList::reload`.
+    /// [`TrackList`] updated. See [`TrackList::reload`].
     ///
-    /// See `get_track_list` and `supports_track_lists` if you want to manually handle compatibility
-    /// checks.
+    /// See [`get_track_list`](Self::get_track_list) and [`supports_track_lists`](Self::supports_track_lists)
+    /// if you want to manually handle compatibility checks.
     pub fn checked_get_track_list(&self) -> Result<Option<TrackList>, DBusError> {
         if self.supports_track_lists() {
             self.get_track_list().map(Some)
@@ -398,12 +420,13 @@ impl<'a> Player<'a> {
 
     /// Query the player to see if it allows changes to its TrackList.
     ///
-    /// Will return `Err` if Player isn't supporting the `TrackList` interface.
+    /// Will return [`Err`] if Player isn't supporting the [`TrackList`] interface.
     ///
-    /// See `checked_can_edit_tracks` to automatically detect players not supporting track lists.
+    /// See [`checked_can_edit_tracks`](Self::checked_can_edit_tracks) to automatically detect players not supporting track lists.
     ///
-    /// See: [MPRIS2 specification about
-    /// `CanEditTracks`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Property:CanEditTracks).
+    /// See: [MPRIS2 specification about `CanEditTracks`][can_edit].
+    ///
+    /// [can_edit]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Property:CanEditTracks
     pub fn can_edit_tracks(&self) -> Result<bool, DBusError> {
         use dbus::ffidisp::stdintf::org_freedesktop_dbus::Properties;
         let connection_path = self.connection_path();
@@ -418,13 +441,14 @@ impl<'a> Player<'a> {
 
     /// Query the player to see if it allows changes to its TrackList.
     ///
-    /// Will return `false` if Player isn't supporting the `TrackList` interface.
+    /// Will return [`false`] if [`Player`] isn't supporting the `TrackList` interface.
     ///
-    /// See `can_edit_tracks` and `supports_track_lists` if you want to manually handle
-    /// compatibility checks.
+    /// See [`can_edit_tracks`](Self::can_edit_tracks) and [`supports_track_lists`](Self::supports_track_lists)
+    /// if you want to manually handle compatibility checks.
     ///
-    /// See: [MPRIS2 specification about
-    /// `CanEditTracks`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Property:CanEditTracks).
+    /// See: [MPRIS2 specification about `CanEditTracks`][can_edit].
+    ///
+    /// [can_edit]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Property:CanEditTracks
     pub fn checked_can_edit_tracks(&self) -> bool {
         if self.supports_track_lists() {
             self.can_edit_tracks().unwrap_or(false)
@@ -433,12 +457,13 @@ impl<'a> Player<'a> {
         }
     }
 
-    /// Query the player for metadata for the given `TrackID`s.
+    /// Query the player for metadata for the given [`TrackID`]s.
     ///
-    /// This is used by the `TrackList` type to iterator metadata for the tracks in the track list.
+    /// This is used by the [`TrackList`] type to iterator metadata for the tracks in the track list.
     ///
-    /// See
-    /// [MediaPlayer2.TrackList.GetTracksMetadata](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:GetTracksMetadata)
+    /// See: [MediaPlayer2.TrackList.GetTracksMetadata][get_meta].
+    ///
+    /// [get_meta]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:GetTracksMetadata
     pub fn get_tracks_metadata(&self, track_ids: &[TrackID]) -> Result<Vec<Metadata>, DBusError> {
         use dbus::arg::IterAppend;
         let connection_path = self.connection_path();
@@ -466,13 +491,14 @@ impl<'a> Player<'a> {
         }
     }
 
-    /// Query the player for metadata for a single `TrackID`.
+    /// Query the player for metadata for a single [`TrackID`].
     ///
-    /// Note that `get_tracks_metadata` with a list is more effective if you have more than a
-    /// single `TrackID` to load.
+    /// Note that [`get_tracks_metadata`](Self::get_tracks_metadata) with a list is more effective if you have more than a
+    /// single [`TrackID`] to load.
     ///
-    /// See
-    /// [MediaPlayer2.TrackList.GetTracksMetadata](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:GetTracksMetadata)
+    /// See: [MediaPlayer2.TrackList.GetTracksMetadata][get_meta].
+    ///
+    /// [get_meta]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:GetTracksMetadata
     pub fn get_track_metadata(&self, track_id: &TrackID) -> Result<Metadata, DBusError> {
         self.get_tracks_metadata(&[track_id.clone()])
             .and_then(|mut result| {
@@ -485,7 +511,7 @@ impl<'a> Player<'a> {
             })
     }
 
-    /// Returns a new `ProgressTracker` for the player.
+    /// Returns a new [`ProgressTracker`] for the player.
     ///
     /// Use this if you want to monitor a player in order to show close-to-realtime information
     /// about it.
@@ -494,16 +520,16 @@ impl<'a> Player<'a> {
     /// interval with the most up-to-date information. It's mostly appropriate when trying to
     /// render something like a progress bar, or information about the current track.
     ///
-    /// See `Player::events` for an alternative approach.
+    /// See: [`events`](Self::events) for an alternative approach.
     pub fn track_progress(&self, interval_ms: u32) -> Result<ProgressTracker<'_>, DBusError> {
         ProgressTracker::new(self, interval_ms)
     }
 
-    /// Returns a `PlayerEvents` iterator, or an `DBusError` if there was a problem with the D-Bus
+    /// Returns a [`PlayerEvents`] iterator, or an [`DBusError`] if there was a problem with the D-Bus
     /// connection to the player.
     ///
     /// This iterator will block until an event for the current player is emitted. This is a lot
-    /// more bare-bones than `Player::track_progress`, but it's also something that makes it easier
+    /// more bare-bones than [`track_progress`](Self::track_progress), but it's also something that makes it easier
     /// for you to translate events into your own application's domain events and only deal with
     /// actual changes.
     ///
@@ -511,7 +537,7 @@ impl<'a> Player<'a> {
     /// appropriate to render a live progress bar using this iterator as the progress bar will
     /// remain frozen until the next event is emitted and the iterator returns.
     ///
-    /// See `Player::track_progress` for an alternative approach.
+    /// See: [`track_progress`](Self::track_progress) for an alternative approach.
     pub fn events(&self) -> Result<PlayerEvents<'_>, DBusError> {
         PlayerEvents::new(self)
     }
@@ -533,49 +559,63 @@ impl<'a> Player<'a> {
 
     /// Send a `PlayPause` signal to the player.
     ///
-    /// See: [MPRIS2 specification about `PlayPause`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:PlayPause)
+    /// See: [MPRIS2 specification about `PlayPause`][play_pause]
+    ///
+    /// [play_pause]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:PlayPause
     pub fn play_pause(&self) -> Result<(), DBusError> {
         self.connection_path().play_pause().map_err(|e| e.into())
     }
 
     /// Send a `Play` signal to the player.
     ///
-    /// See: [MPRIS2 specification about `Play`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Play)
+    /// See: [MPRIS2 specification about `Play`][play].
+    ///
+    /// [play]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Play
     pub fn play(&self) -> Result<(), DBusError> {
         self.connection_path().play().map_err(|e| e.into())
     }
 
     /// Send a `Pause` signal to the player.
     ///
-    /// See: [MPRIS2 specification about `Pause`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Pause)
+    /// See: [MPRIS2 specification about `Pause`][pause].
+    ///
+    /// [pause]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Pause
     pub fn pause(&self) -> Result<(), DBusError> {
         self.connection_path().pause().map_err(|e| e.into())
     }
 
     /// Send a `Stop` signal to the player.
     ///
-    /// See: [MPRIS2 specification about `Stop`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Stop)
+    /// See: [MPRIS2 specification about `Stop`][stop].
+    ///
+    /// [stop]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Stop
     pub fn stop(&self) -> Result<(), DBusError> {
         self.connection_path().stop().map_err(|e| e.into())
     }
 
     /// Send a `Next` signal to the player.
     ///
-    /// See: [MPRIS2 specification about `Next`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Next)
+    /// See: [MPRIS2 specification about `Next`][next].
+    ///
+    /// [next]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Next
     pub fn next(&self) -> Result<(), DBusError> {
         self.connection_path().next().map_err(|e| e.into())
     }
 
     /// Send a `Previous` signal to the player.
     ///
-    /// See: [MPRIS2 specification about `Previous`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Previous)
+    /// See: [MPRIS2 specification about `Previous`][prev].
+    ///
+    /// [prev]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Previous
     pub fn previous(&self) -> Result<(), DBusError> {
         self.connection_path().previous().map_err(|e| e.into())
     }
 
     /// Send a `Seek` signal to the player.
     ///
-    /// See: [MPRIS2 specification about `Seek`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek)
+    /// See: [MPRIS2 specification about `Seek`][seek].
+    ///
+    /// [seek]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek
     pub fn seek(&self, offset_in_microseconds: i64) -> Result<(), DBusError> {
         self.connection_path()
             .seek(offset_in_microseconds)
@@ -584,7 +624,7 @@ impl<'a> Player<'a> {
 
     /// Tell the player to seek forwards.
     ///
-    /// See: `seek` method on `Player`.
+    /// See: [`seek`](Self::seek) method.
     pub fn seek_forwards(&self, offset: &Duration) -> Result<(), DBusError> {
         self.seek(DurationExtensions::as_micros(offset) as i64)
     }
@@ -598,16 +638,16 @@ impl<'a> Player<'a> {
     /// > not have a graphical user interface at all. In this case, the CanRaise property is false
     /// > and this method does nothing.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Raise`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Method:Raise)
-    /// and the `can_raise` method.
+    /// See: [MPRIS2 specification about `Raise`][raise] and the [`can_raise`](Self::can_raise) method.
+    ///
+    /// [raise]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Method:Raise
     pub fn raise(&self) -> Result<(), DBusError> {
         self.connection_path().raise().map_err(|e| e.into())
     }
 
     /// Send a `Raise` signal to the player, if it supports it.
     ///
-    /// See: `can_raise` and `raise` methods.
+    /// See: [`can_raise`](Self::can_raise) and [`raise`](Self::raise) methods.
     pub fn checked_raise(&self) -> Result<bool, DBusError> {
         if self.can_raise()? {
             self.raise().map(|_| true)
@@ -629,16 +669,16 @@ impl<'a> Player<'a> {
     /// >
     /// > If the media player does not have a UI, this should be implemented.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Quit`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Method:Quit)
-    /// and the `can_raise` method.
+    /// See: [MPRIS2 specification about `Quit`][quit] and the [`can_quit`](Self::can_quit) method.
+    ///
+    /// [quit]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Method:Quit
     pub fn quit(&self) -> Result<(), DBusError> {
         self.connection_path().quit().map_err(|e| e.into())
     }
 
     /// Send a `Quit` signal to the player, if it supports it.
     ///
-    /// See: `can_quit` and `quit` methods.
+    /// See: [`can_quit`](Self::can_quit) and [`quit`](Self::quit) methods.
     pub fn checked_quit(&self) -> Result<bool, DBusError> {
         if self.can_quit()? {
             self.quit().map(|_| true)
@@ -649,18 +689,20 @@ impl<'a> Player<'a> {
 
     /// Tell the player to seek backwards.
     ///
-    /// See: `seek` method on `Player`.
+    /// See: [`seek`](Self::seek) method.
     pub fn seek_backwards(&self, offset: &Duration) -> Result<(), DBusError> {
         self.seek(-(DurationExtensions::as_micros(offset) as i64))
     }
 
-    /// Go to a specific track on the Player's TrackList.
+    /// Go to a specific track on the [`Player`]'s [`TrackList`].
     ///
-    /// If the given TrackID is not part of the player's TrackList, it will have no effect.
+    /// If the given [`TrackID`] is not part of the player's [`TrackList`], it will have no effect.
     ///
     /// Requires the player to implement the `TrackList` interface.
     ///
-    /// See: [MPRIS2 specification about `GoTo`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:GoTo)
+    /// See: [MPRIS2 specification about `GoTo`][go_to]
+    ///
+    /// [go_to]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:GoTo
     pub fn go_to(&self, track_id: &TrackID) -> Result<(), DBusError> {
         use crate::generated::OrgMprisMediaPlayer2TrackList;
 
@@ -671,11 +713,13 @@ impl<'a> Player<'a> {
 
     /// Add a URI to the TrackList and optionally set it as current.
     ///
-    /// It is placed after the specified TrackID, if supported by the player.
+    /// It is placed after the specified [`TrackID`], if supported by the player.
     ///
     /// Requires the player to implement the `TrackList` interface.
     ///
-    /// See: [MPRIS2 specification about `AddTrack`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:AddTrack)
+    /// See: [MPRIS2 specification about `AddTrack`][add_track].
+    ///
+    /// [add_track]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:AddTrack
     pub fn add_track(
         &self,
         uri: &str,
@@ -693,7 +737,9 @@ impl<'a> Player<'a> {
     ///
     /// Requires the player to implement the `TrackList` interface.
     ///
-    /// See: [MPRIS2 specification about `AddTrack`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:AddTrack)
+    /// See: [MPRIS2 specification about `AddTrack`][add_track].
+    ///
+    /// [add_track]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:AddTrack
     pub fn add_track_at_start(&self, uri: &str, set_as_current: bool) -> Result<(), DBusError> {
         use crate::generated::OrgMprisMediaPlayer2TrackList;
 
@@ -706,7 +752,9 @@ impl<'a> Player<'a> {
     ///
     /// Requires the player to implement the `TrackList` interface.
     ///
-    /// See: [MPRIS2 specification about `RemoveTrack`](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:RemoveTrack)
+    /// See: [MPRIS2 specification about `RemoveTrack`][remove].
+    ///
+    /// [remove]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Method:RemoveTrack
     pub fn remove_track(&self, track_id: &TrackID) -> Result<(), DBusError> {
         use crate::generated::OrgMprisMediaPlayer2TrackList;
 
@@ -719,7 +767,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `PlayPause`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:PlayPause)
+    /// See: [MPRIS2 specification about `PlayPause`][play_pause]
+    ///
+    /// [play_pause]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:PlayPause
     pub fn checked_play_pause(&self) -> Result<bool, DBusError> {
         if self.can_pause()? {
             self.play_pause().map(|_| true)
@@ -732,7 +782,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Play`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Play)
+    /// See: [MPRIS2 specification about `Play`][play].
+    ///
+    /// [play]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Play
     pub fn checked_play(&self) -> Result<bool, DBusError> {
         if self.can_play()? {
             self.play().map(|_| true)
@@ -745,7 +797,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Pause`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Pause)
+    /// See: [MPRIS2 specification about `Pause`][pause].
+    ///
+    /// [pause]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Pause
     pub fn checked_pause(&self) -> Result<bool, DBusError> {
         if self.can_pause()? {
             self.pause().map(|_| true)
@@ -758,7 +812,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Stop`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Stop)
+    /// See: [MPRIS2 specification about `Stop`][stop].
+    ///
+    /// [stop]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Stop
     pub fn checked_stop(&self) -> Result<bool, DBusError> {
         if self.can_stop()? {
             self.stop().map(|_| true)
@@ -772,7 +828,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Next`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Next)
+    /// See: [MPRIS2 specification about `Next`][next].
+    ///
+    /// [next]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Next
     pub fn checked_next(&self) -> Result<bool, DBusError> {
         if self.can_go_next()? {
             self.next().map(|_| true)
@@ -786,7 +844,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Previous`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Previous)
+    /// See: [MPRIS2 specification about `Previous`][prev].
+    ///
+    /// [prev]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Previous
     pub fn checked_previous(&self) -> Result<bool, DBusError> {
         if self.can_go_previous()? {
             self.previous().map(|_| true)
@@ -799,7 +859,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Seek`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek)
+    /// See: [MPRIS2 specification about `Seek`][seek].
+    ///
+    /// [seek]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek
     pub fn checked_seek(&self, offset_in_microseconds: i64) -> Result<bool, DBusError> {
         if self.can_seek()? {
             self.seek(offset_in_microseconds).map(|_| true)
@@ -812,7 +874,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Seek`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek)
+    /// See: [MPRIS2 specification about `Seek`][seek].
+    ///
+    /// [seek]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek
     pub fn checked_seek_forwards(&self, offset: &Duration) -> Result<bool, DBusError> {
         if self.can_seek()? {
             self.seek_forwards(offset).map(|_| true)
@@ -825,7 +889,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about `Seek`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek)
+    /// See: [MPRIS2 specification about `Seek`][seek].
+    ///
+    /// [seek]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek
     pub fn checked_seek_backwards(&self, offset: &Duration) -> Result<bool, DBusError> {
         if self.can_seek()? {
             self.seek_backwards(offset).map(|_| true)
@@ -836,18 +902,18 @@ impl<'a> Player<'a> {
 
     /// Queries the player to see if it can be raised or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `CanRaise`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:CanRaise)
-    /// and the `raise` method.
+    /// See: [MPRIS2 specification about `CanRaise`][can_raise] and the [`raise`](Self::raise) method.
+    ///
+    /// [can_raise]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:CanRaise
     pub fn can_raise(&self) -> Result<bool, DBusError> {
         self.connection_path().get_can_raise().map_err(|e| e.into())
     }
 
     /// Queries the player to see if it can be asked to quit.
     ///
-    /// See: [MPRIS2 specification about
-    /// `CanQuit`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:CanQuit)
-    /// and the `quit` method.
+    /// See: [MPRIS2 specification about `CanQuit`][can_quit] and the [`quit`](Self::quit) method.
+    ///
+    /// [can_quit]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:CanQuit
     pub fn can_quit(&self) -> Result<bool, DBusError> {
         self.connection_path().get_can_quit().map_err(|e| e.into())
     }
@@ -859,9 +925,9 @@ impl<'a> Player<'a> {
     ///
     /// It is up to you to decide if you want to ignore errors caused by this method or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `CanSetFullscreen`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:CanSetFullscreen)
-    /// and the `set_fullscreen` method.
+    /// See: [MPRIS2 specification about `CanSetFullscreen`][can_full] and the [`set_fullscreen`](Self::set_fullscreen) method.
+    ///
+    /// [can_full]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:CanSetFullscreen
     pub fn can_set_fullscreen(&self) -> Result<bool, DBusError> {
         handle_optional_property(self.connection_path().get_can_set_fullscreen())
             .map(|o| o.unwrap_or(false))
@@ -869,7 +935,9 @@ impl<'a> Player<'a> {
 
     /// Queries the player to see if it can be controlled or not.
     ///
-    /// See: [MPRIS2 specification about `CanControl`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanControl)
+    /// See: [MPRIS2 specification about `CanControl`][can_control].
+    ///
+    /// [can_control]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanControl
     pub fn can_control(&self) -> Result<bool, DBusError> {
         self.connection_path()
             .get_can_control()
@@ -878,7 +946,9 @@ impl<'a> Player<'a> {
 
     /// Queries the player to see if it can go to next or not.
     ///
-    /// See: [MPRIS2 specification about `CanGoNext`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanGoNext)
+    /// See: [MPRIS2 specification about `CanGoNext`][can_next].
+    ///
+    /// [can_next]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanGoNext
     pub fn can_go_next(&self) -> Result<bool, DBusError> {
         self.connection_path()
             .get_can_go_next()
@@ -887,7 +957,9 @@ impl<'a> Player<'a> {
 
     /// Queries the player to see if it can go to previous or not.
     ///
-    /// See: [MPRIS2 specification about `CanGoPrevious`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanGoPrevious)
+    /// See: [MPRIS2 specification about `CanGoPrevious`][can_prev].
+    ///
+    /// [can_prev]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanGoPrevious
     pub fn can_go_previous(&self) -> Result<bool, DBusError> {
         self.connection_path()
             .get_can_go_previous()
@@ -896,32 +968,40 @@ impl<'a> Player<'a> {
 
     /// Queries the player to see if it can pause.
     ///
-    /// See: [MPRIS2 specification about `CanPause`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanPause)
+    /// See: [MPRIS2 specification about `CanPause`][can_pause]
+    ///
+    /// [can_pause]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanPause
     pub fn can_pause(&self) -> Result<bool, DBusError> {
         self.connection_path().get_can_pause().map_err(|e| e.into())
     }
 
     /// Queries the player to see if it can play.
     ///
-    /// See: [MPRIS2 specification about `CanPlay`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanPlay)
+    /// See: [MPRIS2 specification about `CanPlay`][can_play].
+    ///
+    /// [can_play]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanPlay
     pub fn can_play(&self) -> Result<bool, DBusError> {
         self.connection_path().get_can_play().map_err(|e| e.into())
     }
 
     /// Queries the player to see if it can seek within the media.
     ///
-    /// See: [MPRIS2 specification about `CanSeek`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanSeek)
+    /// See: [MPRIS2 specification about `CanSeek`][can_seek].
+    ///
+    /// [can_seek]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanSeek
     pub fn can_seek(&self) -> Result<bool, DBusError> {
         self.connection_path().get_can_seek().map_err(|e| e.into())
     }
 
     /// Queries the player to see if it can stop.
     ///
-    /// MPRIS2 defines [the `Stop` message to only work when the player can be controlled][stop], so that
+    /// MPRIS2 defines [the `Stop` message to only work when the player can be controlled][can_stop], so that
     /// is the property used for this method.
     ///
-    /// See: [MPRIS2 specification about `CanControl`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanControl)
-    /// [stop]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Stop
+    /// See: [MPRIS2 specification about `CanControl`][can_control].
+    ///
+    /// [can_stop]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Stop
+    /// [can_control]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanControl
     pub fn can_stop(&self) -> Result<bool, DBusError> {
         self.can_control()
     }
@@ -989,9 +1069,9 @@ impl<'a> Player<'a> {
     ///
     /// It is up to you to decide if you want to ignore errors caused by this method or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Fullscreen`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:Fullscreen)
-    /// and the `can_set_fullscreen` method.
+    /// See: [MPRIS2 specification about `Fullscreen`][full] and the [`can_set_fullscreen`](Self::can_set_fullscreen) method.
+    ///
+    /// [full]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:Fullscreen
     pub fn get_fullscreen(&self) -> Result<Option<bool>, DBusError> {
         handle_optional_property(self.connection_path().get_fullscreen())
     }
@@ -1003,11 +1083,11 @@ impl<'a> Player<'a> {
     /// This property was added in MPRIS 2.2, and not all players will implement it. This method
     /// will try to detect this case and fall back to `Ok(false)`.
     ///
-    /// Other errors will be returned as `Err`.
+    /// Other errors will be returned as [`Err`].
     ///
-    /// See: [MPRIS2 specification about
-    /// `Fullscreen`](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:Fullscreen)
-    /// and the `can_set_fullscreen` method.
+    /// See: [MPRIS2 specification about `Fullscreen`][full] and the [`can_set_fullscreen`](Self::can_set_fullscreen) method.
+    ///
+    /// [full]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:Fullscreen
     pub fn set_fullscreen(&self, new_state: bool) -> Result<bool, DBusError> {
         handle_optional_property(self.connection_path().set_fullscreen(new_state))
             .map(|o| o.is_some())
@@ -1023,8 +1103,9 @@ impl<'a> Player<'a> {
 
     /// Query player for the state of the "Shuffle" setting.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Shuffle`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Shuffle)
+    /// See: [MPRIS2 specification about `Shuffle`][shuffle].
+    ///
+    /// [shuffle]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Shuffle
     pub fn get_shuffle(&self) -> Result<bool, DBusError> {
         self.connection_path()
             .get_shuffle()
@@ -1033,8 +1114,8 @@ impl<'a> Player<'a> {
 
     /// Gets the "Shuffle" setting, if the player indicates that it supports it.
     ///
-    /// Return [[Some]] containing the current value of the shuffle setting. If the setting is not
-    /// supported, will return [[None]]
+    /// Return [`Some`] containing the current value of the shuffle setting. If the setting is not
+    /// supported, will return [`None`]
     pub fn checked_get_shuffle(&self) -> Result<Option<bool>, DBusError> {
         if self.can_shuffle()? {
             Ok(Some(self.get_shuffle()?))
@@ -1045,8 +1126,9 @@ impl<'a> Player<'a> {
 
     /// Set the "Shuffle" setting of the player.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Shuffle`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Shuffle)
+    /// See: [MPRIS2 specification about `Shuffle`][shuffle].
+    ///
+    /// [shuffle]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Shuffle
     pub fn set_shuffle(&self, state: bool) -> Result<(), DBusError> {
         self.connection_path()
             .set_shuffle(state)
@@ -1056,10 +1138,11 @@ impl<'a> Player<'a> {
     /// Set the "Shuffle" setting of the player, if the player indicates that it supports the
     /// "Shuffle" setting and can be controlled.
     ///
-    /// Returns a boolean to show if the signal was sent or not.
+    /// Returns a [`bool`] to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Shuffle`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Shuffle)
+    /// See: [MPRIS2 specification about `Shuffle`][shuffle].
+    ///
+    /// [shuffle]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Shuffle
     pub fn checked_set_shuffle(&self, state: bool) -> Result<bool, DBusError> {
         if self.can_control()? && self.can_shuffle()? {
             self.set_shuffle(state)
@@ -1072,8 +1155,9 @@ impl<'a> Player<'a> {
 
     /// Query the player for the current loop status.
     ///
-    /// See: [MPRIS2 specification about
-    /// `LoopStatus`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:LoopStatus)
+    /// See: [MPRIS2 specification about  `LoopStatus`][loop_status].
+    ///
+    /// [loop_status]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:LoopStatus
     pub fn get_loop_status(&self) -> Result<LoopStatus, DBusError> {
         self.connection_path()
             .get_loop_status()?
@@ -1083,8 +1167,8 @@ impl<'a> Player<'a> {
 
     /// Gets the "LoopStatus" setting, if the player indicates that it supports it.
     ///
-    /// Returns [[Some]] containing the current value of the loop setting. If the setting is not
-    /// supported, returns [[None]]
+    /// Returns [`Some`] containing the current value of the loop setting. If the setting is not
+    /// supported, returns [`None`]
     pub fn checked_get_loop_status(&self) -> Result<Option<LoopStatus>, DBusError> {
         if self.can_loop()? {
             Ok(Some(self.get_loop_status()?))
@@ -1095,8 +1179,9 @@ impl<'a> Player<'a> {
 
     /// Set the loop status of the player.
     ///
-    /// See: [MPRIS2 specification about
-    /// `LoopStatus`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:LoopStatus)
+    /// See: [MPRIS2 specification about  `LoopStatus`][loop_status].
+    ///
+    /// [loop_status]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:LoopStatus
     pub fn set_loop_status(&self, status: LoopStatus) -> Result<(), DBusError> {
         self.connection_path()
             .set_loop_status(status.dbus_value())
@@ -1108,8 +1193,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `LoopStatus`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:LoopStatus)
+    /// See: [MPRIS2 specification about  `LoopStatus`][loop_status].
+    ///
+    /// [loop_status]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:LoopStatus
     pub fn checked_set_loop_status(&self, status: LoopStatus) -> Result<bool, DBusError> {
         if self.can_control()? && self.can_loop()? {
             self.set_loop_status(status)
@@ -1125,16 +1211,17 @@ impl<'a> Player<'a> {
     /// Volume should be between 0.0 and 1.0. Above 1.0 is possible, but not
     /// recommended.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Volume`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume)
+    /// See: [MPRIS2 specification about `Volume`][vol].
+    ///
+    /// [vol]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume
     pub fn get_volume(&self) -> Result<f64, DBusError> {
         self.connection_path().get_volume().map_err(DBusError::from)
     }
 
     /// Gets the "Volume" setting, if the player indicates that it supports it.
     ///
-    /// Returns [[Some]] containing the current value of the position. If the setting is not
-    /// supported, returns [[None]]
+    /// Returns [`Some`] containing the current value of the position. If the setting is not
+    /// supported, returns [`None`]
     pub fn checked_get_volume(&self) -> Result<Option<f64>, DBusError> {
         if self.has_volume()? {
             Ok(Some(self.get_volume()?))
@@ -1148,8 +1235,9 @@ impl<'a> Player<'a> {
     /// Volume should be between 0.0 and 1.0. Above 1.0 is possible, but not
     /// recommended.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Volume`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume)
+    /// See: [MPRIS2 specification about `Volume`][vol].
+    ///
+    /// [vol]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume
     pub fn set_volume(&self, value: f64) -> Result<(), DBusError> {
         self.connection_path()
             .set_volume(value.max(0.0))
@@ -1161,8 +1249,9 @@ impl<'a> Player<'a> {
     ///
     /// Returns a boolean to show if the signal was sent or not.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Volume`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume)
+    /// See: [MPRIS2 specification about `Volume`][vol].
+    ///
+    /// [vol]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume
     pub fn checked_set_volume(&self, volume: f64) -> Result<bool, DBusError> {
         if self.can_control()? && self.has_volume()? {
             self.set_volume(volume)
@@ -1179,8 +1268,9 @@ impl<'a> Player<'a> {
     /// Volume should be between 0.0 and 1.0. Above 1.0 is possible, but not
     /// recommended.
     ///
-    /// See: [MPRIS2 specification about
-    /// `Volume`](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume)
+    /// See: [MPRIS2 specification about `Volume`][vol].
+    ///
+    /// [vol]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Volume
     pub fn set_volume_checked(&self, value: f64) -> Result<bool, DBusError> {
         if self.can_control()? {
             self.set_volume(value).map(|_| true)

--- a/src/pooled_connection.rs
+++ b/src/pooled_connection.rs
@@ -22,7 +22,7 @@ const NAME_HAS_OWNER_TIMEOUT: i32 = 100; // ms
 
 impl PooledConnection {
     pub(crate) fn new(connection: Connection) -> Self {
-        // Subscribe to events that relate to players. See `MprisMessage` below for details.
+        // Subscribe to events that relate to players. See [`MprisMessage`] below for details.
         let _ = connection.add_match(
             "interface='org.freedesktop.DBus.Properties',member='PropertiesChanged',path='/org/mpris/MediaPlayer2'",
         );
@@ -86,9 +86,9 @@ impl PooledConnection {
             .and_then(|reply| reply.get1())
     }
 
-    /// Returns `true` if the given bus name has any pending events waiting to be processed.
+    /// Returns [`true`] if the given bus name has any pending events waiting to be processed.
     ///
-    /// If you want to actually act on the messages, use `pending_events`.
+    /// If you want to actually act on the messages, use [`pending_events`](Self::pending_events).
     pub(crate) fn has_pending_events(&self, bus_name: &str) -> bool {
         self.events
             .try_borrow()
@@ -100,7 +100,7 @@ impl PooledConnection {
     /// Removes all pending events from a bus' queue and returns them.
     ///
     /// If you want to non-destructively check if a bus has anything queued, use
-    /// `has_pending_events`.
+    /// [`has_pending_events`](Self::has_pending_events).
     pub(crate) fn pending_events(&self, bus_name: &str) -> Vec<MprisEvent> {
         self.events
             .try_borrow_mut()
@@ -109,7 +109,7 @@ impl PooledConnection {
             .unwrap_or_default()
     }
 
-    /// Process events in a blocking fashion until the deadline/timebox `Duration` runs out.
+    /// Process events in a blocking fashion until the deadline/timebox [`Duration`] runs out.
     pub(crate) fn process_events_blocking_for(&self, duration: Duration) {
         let start = Instant::now();
 
@@ -153,7 +153,7 @@ impl PooledConnection {
     }
 
     /// Takes a message and processes it appropriately. Returns the affected bus name, and a borrow
-    /// to the generated MprisEvent, if applicable.
+    /// to the generated [`MprisEvent`], if applicable.
     fn process_message(&self, message: MprisMessage) {
         let mut events = match self.events.try_borrow_mut() {
             Ok(val) => val,
@@ -276,7 +276,7 @@ pub(crate) enum MprisEvent {
     },
 }
 
-/// Easier to use representation of supported D-Bus messages.
+/// Easier to use representation of supported [`D-Bus message`](Message).
 #[derive(Debug)]
 pub(crate) enum MprisMessage {
     NameOwnerChanged {
@@ -315,14 +315,14 @@ pub(crate) enum MprisMessage {
 }
 
 impl MprisMessage {
-    /// Tries to convert the provided D-Bus message into a MprisMessage; returns None if the
+    /// Tries to convert the provided [`D-Bus message`](Message) into a MprisMessage; returns [`None`] if the
     /// message was not supported.
     fn try_parse(message: Message) -> Option<Self> {
         MprisMessage::try_parse_name_owner_changed(&message)
             .or_else(|| MprisMessage::try_parse_mpris_signal(&message))
     }
 
-    /// Return a MprisMessage::NameOwnerChanged if the provided D-Bus message is a
+    /// Return a [`MprisMessage::NameOwnerChanged`] if the provided D-Bus message is a
     /// org.freedesktop.DBus NameOwnerChanged message.
     fn try_parse_name_owner_changed(message: &Message) -> Option<Self> {
         match (message.sender(), message.member()) {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -7,7 +7,7 @@ use crate::metadata::Metadata;
 use crate::player::Player;
 use crate::pooled_connection::MprisEvent;
 
-/// Struct containing information about current progress of a Player.
+/// Struct containing information about current progress of a [`Player`].
 ///
 /// It has access to the metadata of the current track, as well as information about the current
 /// position of the track.
@@ -29,9 +29,9 @@ pub struct Progress {
     current_volume: f64,
 }
 
-/// Controller for calculating `Progress` and maintaining a `TrackList` (if supported) for a given `Player`.
+/// Controller for calculating [`Progress`] and maintaining a [`TrackList`] (if supported) for a given [`Player`].
 ///
-/// Call the `tick` method to get the most current `Progress` data.
+/// Call the [`tick`](Self::tick) method to get the most current [`Progress`] data.
 #[derive(Debug)]
 pub struct ProgressTracker<'a> {
     player: &'a Player<'a>,
@@ -41,17 +41,17 @@ pub struct ProgressTracker<'a> {
     last_progress: Progress,
 }
 
-/// Return value of `ProgressTracker::tick`, which gives details about the latest refresh.
+/// Return value of [`ProgressTracker::tick`](ProgressTracker::tick), which gives details about the latest refresh.
 #[derive(Debug)]
 pub struct ProgressTick<'a> {
-    /// `true` if `Player` quit. This likely means that the player is no longer running.
+    /// [`true`] if [`Player`] quit. This likely means that the player is no longer running.
     ///
     /// If the player is no longer running, then fetching new data will not be possible,
-    /// so they will all be reused (`progress_changed` and `track_list_changed` should all be
-    /// `false`).
+    /// so they will all be reused ([`progress_changed`](Self::progress_changed) and
+    /// [`track_list_changed`](Self::track_list_changed) should all be [`false`]).
     pub player_quit: bool,
 
-    /// `true` if `Progress` data changed (beyond the calculated `position`)
+    /// [`true`] if [`Progress`] data changed (beyond the calculated `position`)
     ///
     /// **Examples:**
     ///
@@ -60,7 +60,7 @@ pub struct ProgressTick<'a> {
     /// * Volume was decreased
     pub progress_changed: bool,
 
-    /// `true` if `TrackList` data changed. This will always be `false` if player does not support
+    /// [`true`] if [`TrackList`] data changed. This will always be [`false`] if player does not support
     /// track lists.
     ///
     /// **Examples:**
@@ -70,34 +70,34 @@ pub struct ProgressTick<'a> {
     /// * Metadata changed for a track
     pub track_list_changed: bool,
 
-    /// The current `Progress` from the `ProgressTracker`. `progress_changed` tells you if this was
-    /// reused from the last tick or if it's a new one.
+    /// The current [`Progress`] from the [`ProgressTracker`]. [`progress_changed`](Self::progress_changed)
+    /// tells you if this was reused from the last tick or if it's a new one.
     pub progress: &'a Progress,
 
-    /// The current `TrackList` from the `ProgressTracker`. `track_list_changed` tells you if this was
-    /// changed since the last tick.
+    /// The current [`TrackList`] from the [`ProgressTracker`]. [`track_list_changed`](Self::track_list_changed)
+    /// tells you if this was changed since the last tick.
     pub track_list: Option<&'a TrackList>,
 }
 
 /// Errors that can occur while refreshing progress.
 #[derive(Debug, Fail)]
 pub enum ProgressError {
-    /// Something went wrong with the D-Bus communication. See the `DBusError` type.
+    /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
     #[fail(display = "D-Bus communication failed")]
     DBusError(#[cause] DBusError),
 
-    /// Something went wrong with the track list. See the `TrackListError` type.
+    /// Something went wrong with the track list. See the [`TrackListError`] type.
     #[fail(display = "TrackList could not be refreshed")]
     TrackListError(#[cause] TrackListError),
 }
 
 impl<'a> ProgressTracker<'a> {
-    /// Construct a new `ProgressTracker` for the provided `Player`.
+    /// Construct a new [`ProgressTracker`] for the provided [`Player`].
     ///
-    /// The `interval_ms` value is the desired time between ticks when calling the `tick` method.
-    /// See `tick` for more information about that.
+    /// The `interval_ms` value is the desired time between ticks when calling the [`tick`](Self::tick) method.
+    /// See [`tick`](Self::tick) for more information about that.
     ///
-    /// You probably want to use `Player::track_progress` instead of this method.
+    /// You probably want to use [`Player::track_progress`] instead of this method.
     ///
     /// # Errors
     ///
@@ -112,10 +112,10 @@ impl<'a> ProgressTracker<'a> {
         })
     }
 
-    /// Returns a `ProgressTick` at each interval, or as close to each interval as possible.
+    /// Returns a [`ProgressTick`] at each interval, or as close to each interval as possible.
     ///
     /// The returned struct contains borrows of the current data along with booleans telling you if
-    /// the underlying data changed or not. See `ProgressTick` for more information about that.
+    /// the underlying data changed or not. See [`ProgressTick`] for more information about that.
     ///
     /// If there is time left until the next interval window, then the tracker will process DBus
     /// events to determine if something changed (and potentially perform a full refresh of the
@@ -127,18 +127,18 @@ impl<'a> ProgressTracker<'a> {
     ///
     /// ## On reusing data
     ///
-    /// `Progress` can be reused until something about the player changes, like track or playback
-    /// status. As long as nothing changes, `Progress` can accurately determine playback position
+    /// [`Progress`] can be reused until something about the player changes, like track or playback
+    /// status. As long as nothing changes, [`Progress`] can accurately determine playback position
     /// from timing data.
     ///
-    /// In addition, `TrackList` will maintain a cache of track metadata so as long as the list
+    /// In addition, [`TrackList`] will maintain a cache of track metadata so as long as the list
     /// remains static if should be cheap to read from it.
     ///
-    /// You can use the `bool`s in the `ProgressTick` to perform optimizations as they tell you if
-    /// any data has changed. If all of them are `false` you don't have to treat any of the data as
+    /// You can use the [`bool`]s in the [`ProgressTick`] to perform optimizations as they tell you if
+    /// any data has changed. If all of them are [`false`] you don't have to treat any of the data as
     /// dirty.
     ///
-    /// The calculated `Progress::position` might still change depending on the player state, so if
+    /// The calculated [`Progress::position`] might still change depending on the player state, so if
     /// you want to show the track position you might still want to refresh that part.
     ///
     /// # Examples
@@ -160,7 +160,7 @@ impl<'a> ProgressTracker<'a> {
     /// }
     /// ```
     ///
-    /// Using the `progress_changed` `bool`:
+    /// Using the [`progress_changed`](ProgressTick::progress_changed) [`bool`]:
     ///
     /// ```rust,no_run
     /// # use mpris::PlayerFinder;
@@ -290,8 +290,8 @@ impl<'a> ProgressTracker<'a> {
 
     /// Force a refresh right now.
     ///
-    /// This will ignore the interval and perform a refresh anyway. The new `Progress` will be
-    /// saved, and the `TrackList` will be refreshed.
+    /// This will ignore the interval and perform a refresh anyway. The new [`Progress`] will be
+    /// saved, and the [`TrackList`] will be refreshed.
     ///
     /// # Errors
     ///
@@ -363,52 +363,54 @@ impl Progress {
         self.rate
     }
 
-    /// Returns the length of the current track as a `Duration`.
+    /// Returns the length of the current track as a [`Duration`].
     pub fn length(&self) -> Option<Duration> {
         self.metadata.length()
     }
 
-    /// Returns the current position of the current track as a `Duration`.
+    /// Returns the current position of the current track as a [`Duration`].
     ///
     /// This method will calculate the expected position of the track at the instant of the
-    /// invocation using the `initial_position` and knowledge of how long ago that position was
+    /// invocation using the [`initial_position`](Self::initial_position) and knowledge of how long ago that position was
     /// determined.
     ///
     /// **Note:** Some players might not support this and will return a bad position. Spotify is
     /// one such example. There is no reliable way of detecting problematic players, so it will be
     /// up to your client to check for this.
     ///
-    /// One way of doing this is to query the `initial_position` for two measures with the
-    /// `Playing` `PlaybackStatus` and if both are `0`, then it is likely that this client does not
+    /// One way of doing this is to query the [`initial_position`](Self::initial_position) for two measures with the
+    /// [`PlaybackStatus::Playing`] and if both are `0`, then it is likely that this client does not
     /// support positions.
     pub fn position(&self) -> Duration {
         self.position + self.elapsed()
     }
 
-    /// Returns the position that the current track was at when the `Progress` was created.
+    /// Returns the position that the current track was at when the [`Progress`] was created.
     ///
-    /// This is the number that was returned for the `Position` property in the MPRIS2 interface.
+    /// This is the number that was returned for the [`Position`][position] property in the MPRIS2 interface.
+    ///
+    /// [position]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:Position
     pub fn initial_position(&self) -> Duration {
         self.position
     }
 
-    /// The instant where this `Progress` was recorded.
+    /// The instant where this [`Progress`] was recorded.
     ///
-    /// See: `age`.
+    /// See: [`age`](Self::age).
     pub fn created_at(&self) -> &Instant {
         &self.instant
     }
 
-    /// Returns the age of the data as a `Duration`.
+    /// Returns the age of the data as a [`Duration`].
     ///
-    /// If the `Progress` has a high age it is more likely to be out of date.
+    /// If the [`Progress`] has a high age it is more likely to be out of date.
     pub fn age(&self) -> Duration {
         self.instant.elapsed()
     }
 
     /// Returns the player's volume as it was at the time of refresh.
     ///
-    /// See: `Player::get_volume`.
+    /// See: [`Player::get_volume`].
     pub fn current_volume(&self) -> f64 {
         self.current_volume
     }

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -18,7 +18,7 @@ pub(crate) const NO_TRACK: &str = "/org/mpris/MediaPlayer2/TrackList/NoTrack";
 ///
 /// # Errors
 ///
-/// Trying to construct a `TrackID` from a string that is not a valid D-Bus Path will fail.
+/// Trying to construct a [`TrackID`] from a string that is not a valid D-Bus Path will fail.
 ///
 /// ```rust
 /// # use mpris::TrackID;
@@ -30,16 +30,15 @@ pub(crate) const NO_TRACK: &str = "/org/mpris/MediaPlayer2/TrackList/NoTrack";
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub struct TrackID(pub(crate) String);
 
-/// Represents a MediaPlayer2.TrackList.
+/// Represents a [`MediaPlayer2.TrackList`][track_list].
 ///
-/// This type offers an iterator of the track's metadata, when provided a `Player` instance that
+/// This type offers an iterator of the track's metadata, when provided a [`Player`] instance that
 /// matches the list.
 ///
 /// TrackLists cache metadata about tracks so multiple iterations should be fast. It also enables
 /// signals received from the Player to pre-populate metadata and to keep everything up to date.
 ///
-/// See [MediaPlayer2.TrackList
-/// interface](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html)
+/// [track_list]: https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html
 #[derive(Debug, Default)]
 pub struct TrackList {
     ids: Vec<TrackID>,
@@ -48,11 +47,11 @@ pub struct TrackList {
 
 /// TrackList-related errors.
 ///
-/// This is mostly `DBusError` with the extra possibility of borrow errors of the internal metadata
+/// This is mostly [`DBusError`] with the extra possibility of borrow errors of the internal metadata
 /// cache.
 #[derive(Debug, Fail)]
 pub enum TrackListError {
-    /// Something went wrong with the D-Bus communication. See the `DBusError` type.
+    /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
     #[fail(display = "D-Bus communication failed")]
     DBusError(#[cause] DBusError),
 
@@ -101,12 +100,12 @@ impl fmt::Display for TrackID {
 }
 
 impl TrackID {
-    /// Create a new `TrackID` from a string-like entity.
+    /// Create a new [`TrackID`] from a string-like entity.
     ///
     /// This is not something you should normally do as the IDs are temporary and will only work if
     /// the Player knows about it.
     ///
-    /// However, creating `TrackID`s manually can help with test setup, comparisons, etc.
+    /// However, creating [`TrackID`]s manually can help with test setup, comparisons, etc.
     ///
     /// # Example
     /// ```rust
@@ -123,7 +122,7 @@ impl TrackID {
         }
     }
 
-    /// Return a new TrackID that matches the MPRIS standard for the "No track" sentinel value.
+    /// Return a new [`TrackID`] that matches the MPRIS standard for the "No track" sentinel value.
     ///
     /// Some APIs takes this in order to signal a missing value for a track, for example by saying
     /// that no specific track is playing, or that a track should be added at the start of the
@@ -131,8 +130,10 @@ impl TrackID {
     ///
     /// The actual path is "/org/mpris/MediaPlayer2/TrackList/NoTrack".
     ///
-    /// This value is only valid in some cases. Make sure to read the MPRIS specification before
-    /// you use this manually.
+    /// This value is only valid in some cases. Make sure to read the [MPRIS specification before
+    /// you use this manually][track_id].
+    ///
+    /// [track_id]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Simple-Type:Track_Id
     pub fn no_track() -> Self {
         TrackID(NO_TRACK.into())
     }
@@ -143,7 +144,7 @@ impl TrackID {
     }
 
     pub(crate) fn as_path(&self) -> dbus::Path<'_> {
-        // All inputs to this class should be validated to work with dbus::Path, so unwrapping
+        // All inputs to this class should be validated to work with [`dbus::Path`], so unwrapping
         // should be safe here.
         dbus::Path::new(self.as_str()).unwrap()
     }
@@ -168,7 +169,7 @@ impl FromIterator<TrackID> for TrackList {
 }
 
 impl TrackList {
-    /// Construct a new TrackList without any existing cache.
+    /// Construct a new [`TrackList`] without any existing cache.
     pub fn new(ids: Vec<TrackID>) -> TrackList {
         TrackList {
             metadata_cache: RefCell::new(HashMap::with_capacity(ids.len())),
@@ -176,7 +177,7 @@ impl TrackList {
         }
     }
 
-    /// Get a list of TrackIDs that are part of this TrackList. The order matters.
+    /// Get a list of [`TrackID`]s that are part of this [`TrackList`]. The order matters.
     pub fn ids(&self) -> &[TrackID] {
         self.ids.as_ref()
     }
@@ -191,7 +192,7 @@ impl TrackList {
         self.ids.is_empty()
     }
 
-    /// Return the TrackID of the index. Out-of-bounds will result in `None`.
+    /// Return the [`TrackID`] of the index. Out-of-bounds will result in [`None`].
     pub fn get(&self, index: usize) -> Option<&TrackID> {
         self.ids.get(index)
     }
@@ -201,7 +202,7 @@ impl TrackList {
     ///
     /// **NOTE:** This is *not* something that will affect a player's actual tracklist; this is
     /// strictly for client-side representation. Use this if you want to maintain your own instance
-    /// of `TrackList` or to feed your code with test fixtures.
+    /// of [`TrackList`] or to feed your code with test fixtures.
     pub fn insert(&mut self, after: &TrackID, metadata: Metadata) {
         let new_id = match metadata.track_id() {
             Some(val) => val,
@@ -248,13 +249,13 @@ impl TrackList {
         });
     }
 
-    /// Adds/updates the metadata cache for a track (as identified by `Metadata::track_id`).
+    /// Adds/updates the metadata cache for a track (as identified by [`Metadata::track_id`]).
     ///
-    /// The metadata will be added to the cache even if the `TrackID` isn't part of the list, but
+    /// The metadata will be added to the cache even if the [`TrackID`] isn't part of the list, but
     /// will be cleaned out again after the next cache cleanup unless the track in question have
     /// been added to the list before then.
     ///
-    /// If provided metadata does not contain a `TrackID`, the metadata will be discarded.
+    /// If provided metadata does not contain a [`TrackID`], the metadata will be discarded.
     pub fn add_metadata(&mut self, metadata: Metadata) {
         if let Some(id) = metadata.track_id() {
             self.change_metadata(|cache| cache.insert(id.to_owned(), metadata));
@@ -266,10 +267,10 @@ impl TrackList {
     ///
     /// The new ID (which *might* be identical to the old ID) will be returned by this method.
     ///
-    /// If the old ID cannot be found, the metadata will be discarded and `None` will be returned.
+    /// If the old ID cannot be found, the metadata will be discarded and [`None`] will be returned.
     ///
-    /// If provided metadata does not contain a `TrackID`, the metadata will be discarded and
-    /// `None` will be returned.
+    /// If provided metadata does not contain a [`TrackID`], the metadata will be discarded and
+    /// [`None`] will be returned.
     pub fn replace_track_metadata(
         &mut self,
         old_id: &TrackID,
@@ -287,11 +288,11 @@ impl TrackList {
         None
     }
 
-    /// Iterates the tracks in the tracklist, returning a tuple of TrackID and Metadata for that
+    /// Iterates the tracks in the tracklist, returning a tuple of [`TrackID`] and [`Metadata`] for that
     /// track.
     ///
-    /// Metadata will be loaded from the provided player when not present in the metadata cache.
-    /// If metadata loading fails, then a DBusError will be returned instead of the iterator.
+    /// [`Metadata`] will be loaded from the provided player when not present in the metadata cache.
+    /// If metadata loading fails, then a [`DBusError`] will be returned instead of the iterator.
     pub fn metadata_iter(&self, player: &Player<'_>) -> Result<MetadataIter, TrackListError> {
         self.complete_cache(player)?;
         let metadata: HashMap<_, _> = self.metadata_cache.clone().into_inner();
@@ -333,7 +334,7 @@ impl TrackList {
         Ok(())
     }
 
-    /// Fill in any holes in the cache so that each track on the list has a cached Metadata entry.
+    /// Fill in any holes in the cache so that each track on the list has a cached [`Metadata`] entry.
     ///
     /// If all tracks already have a cache entry, then this will do nothing.
     pub fn complete_cache(&self, player: &Player<'_>) -> Result<(), TrackListError> {


### PR DESCRIPTION
When listening to a stream (internet radio) and using the `PlayerEvents` iterator new events won't be created because only the `TrackID` and URL get checked and those will stay the same in a stream even when other metadata changes. This PR adds 2 additional checks to fix this. It checks `title` and `artists`. `Title` is checked first because streams (from my experience) set the `artists` metadata to the stream name and set the `title` to "Artist - Title". `Artists` is checked second just in case the metadata is set properly. There is still the edge case of 2 songs with the same artist and title being played back to back which will not cause a new event to be added but that is very unlikely.
This PR also has quite a lot of documentation changes, mostly just added links to mentioned struct/enum/function for easier navigation and some fixes to broken hyperlinks.