### PR TITLE
Change finder methods

### DIFF
--- a/src/find.rs
+++ b/src/find.rs
@@ -8,6 +8,7 @@ use dbus::{arg, Message};
 use super::DBusError;
 use crate::player::{Player, DEFAULT_TIMEOUT_MS, MPRIS2_PATH, MPRIS2_PREFIX};
 use crate::pooled_connection::PooledConnection;
+use crate::PlaybackStatus;
 
 const LIST_NAMES_TIMEOUT_MS: i32 = 500;
 
@@ -36,6 +37,8 @@ impl From<DBusError> for FindingError {
 }
 
 /// Used to find [`Player`]s running on a D-Bus connection.
+///
+/// All find results are sorted in alphabetical order.
 #[derive(Debug)]
 pub struct PlayerFinder {
     connection: Rc<PooledConnection>,
@@ -78,17 +81,10 @@ impl PlayerFinder {
             .collect()
     }
 
-    /// Try to find the "active" player in the connection.
-    ///
-    /// MPRIS does not have the concept of "active" and all players are treated the same, even if
-    /// only one of the players are currently playing something.
-    ///
-    /// This method will try to determine which player a user is most likely to use.
-    ///
-    /// **NOTE:** Currently this method is very naive and just returns the first player. This
-    /// behavior can change later without a major version change, so don't rely on that behavior.
-    pub fn find_active<'b>(&self) -> Result<Player<'b>, FindingError> {
-        if let Some(bus_name) = self.active_player_bus()? {
+    /// Return the first found [`Player`] regardless of state.
+    pub fn find_first<'b>(&self) -> Result<Player<'b>, FindingError> {
+        let busses = self.all_player_buses()?;
+        if let Some(bus_name) = busses.into_iter().next() {
             Player::for_pooled_connection(
                 Rc::clone(&self.connection),
                 bus_name.into(),
@@ -101,10 +97,56 @@ impl PlayerFinder {
         }
     }
 
-    fn active_player_bus(&self) -> Result<Option<String>, FindingError> {
-        // Right now, we just pick the first of the players. Is there some way to select this more
-        // intelligently?
-        Ok(self.all_player_buses()?.into_iter().next())
+    /// Try to find the "active" [`Player`] in the connection.
+    ///
+    /// This method will try to determine which player a user is most likely to use. First it will look for a player with
+    /// the playback status [`Playing`](PlaybackStatus::Playing), then for a [`Paused`](PlaybackStatus::Paused), then one with
+    /// track metadata, after that it will just return the first it finds. [`NoPlayerFound`](FindingError::NoPlayerFound) is returned
+    /// only if there is no player on the DBus.
+    pub fn find_active<'b>(&self) -> Result<Player<'b>, FindingError> {
+        let mut players: Vec<Player> = self.find_all()?;
+
+        // Return Error if no players
+        if players.is_empty() {
+            return Err(FindingError::NoPlayerFound);
+        }
+
+        // Look for "Playing"
+        for (n, player) in players.iter().enumerate() {
+            if let PlaybackStatus::Playing = player.get_playback_status()? {
+                return Ok(players.remove(n));
+            }
+        }
+
+        // Look for "Paused"
+        for (n, player) in players.iter().enumerate() {
+            if let PlaybackStatus::Paused = player.get_playback_status()? {
+                return Ok(players.remove(n));
+            }
+        }
+
+        // Look for player with metadata
+        for (n, player) in players.iter().enumerate() {
+            if !player.get_metadata()?.as_hashmap().is_empty() {
+                return Ok(players.remove(n));
+            }
+        }
+
+        // Finally just return any player
+        Ok(players.remove(0))
+    }
+
+    /// Find a [`Player`] by it's MPRIS [`Identity`][identity]. Returns [`NoPlayerFound`](FindingError::NoPlayerFound) if no direct match found.
+    ///
+    /// [identity]: https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:Identity
+    pub fn find_by_name<'b>(&self, name: &str) -> Result<Player<'b>, FindingError> {
+        let players = self.find_all()?;
+        for player in players {
+            if player.identity() == name {
+                return Ok(player);
+            }
+        }
+        Err(FindingError::NoPlayerFound)
     }
 
     fn all_player_buses(&self) -> Result<Vec<String>, DBusError> {
@@ -123,9 +165,11 @@ impl PlayerFinder {
 
         let names: arg::Array<'_, &str, _> = reply.read1().map_err(DBusError::from)?;
 
-        Ok(names
+        let mut all_busses = names
             .filter(|name| name.starts_with(MPRIS2_PREFIX))
             .map(|str_ref| str_ref.to_owned())
-            .collect())
+            .collect::<Vec<String>>();
+        all_busses.sort_by_key(|a| a.to_lowercase());
+        Ok(all_busses)
     }
 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -134,7 +134,7 @@ impl PlayerFinder {
                 first_paused.replace(index);
             }
 
-            if first_with_track.is_none() && !player.get_metadata()?.as_hashmap().is_empty() {
+            if first_with_track.is_none() && !player.get_metadata()?.is_empty() {
                 first_with_track.replace(index);
             }
         }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -172,6 +172,11 @@ impl Metadata {
     pub fn keys(&self) -> impl Iterator<Item = &str> {
         self.values.keys().map(String::as_str)
     }
+
+    /// Returns [`true`] if there is no metadata
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
 }
 
 impl IntoIterator for Metadata {


### PR DESCRIPTION
Implements changes mentioned in #57

All find methods are now sorted alphabetically by their bus name which are (probably) a better way to sort than the MPRIS Identity property. For example, Firefox sets it's bus name to `org.mpris.MediaPlayer2.firefox.instanceXXX` while the Identity is `Mozilla Firefox` and it makes more sense to sort by just `Firefox`.
`find_active` now first looks for a playing player, then paused, then one with track metadata and after that fails returns the first found. I'm not sure if there is a better way of implementing it since it requires iterating over a `Vec` multiple times and Rust doesn't like that.
Added `find_first` which just returns the first player found.
Added `find_by_name` which finds a player by it's MPRIS Identity property.

I've tested this with Cantata, Firefox, mpv and Dragon Player. Seems to work as intended but I will try to test it with more players just in case.