### PR TITLE
Replace failure with thiserror & anyhow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `Progress` default values uses `checked_get_*` functions - [Harrison
   Thorne (harrisonthorne)][harrisonthorne]
 * Documentation was made easier to navigate - [Kanjirito][Kanjirito]
-
+* Use `thiserror` & `anyhow` instead of unmaintained `failure` - [fengalin][fengalin]
 
 ## [v2.0.0-rc2] - 2020-02-15
 
@@ -199,3 +199,4 @@ versions.
 [Kilobyte22]: https://github.com/Kilobyte22
 [harrisonthorne]: https://github.com/harrisonthorne
 [Kanjirito]: https://github.com/Kanjirito
+[fengalin]: https://github.com/fengalin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 dbus = "0.9.5"
-failure = "0.1.8"
-failure_derive = "0.1.8"
-enum-kinds = "0.5.1"
 derive_is_enum_variant = "0.1.1"
+enum-kinds = "0.5.1"
 from_variants = "0.6.0"
+thiserror = "1.0.30"
 
 # For examples
 [dev-dependencies]
+anyhow = "1.0.52"
 termion = "1.5.6"

--- a/examples/capabilities.rs
+++ b/examples/capabilities.rs
@@ -1,4 +1,4 @@
-use failure::{Error, ResultExt};
+use anyhow::{Context, Result};
 use mpris::{DBusError, Player, PlayerFinder};
 use std::borrow::Cow;
 
@@ -13,7 +13,7 @@ fn main() {
         Ok(_) => {}
         Err(error) => {
             println!("Error: {}", error);
-            for (i, cause) in error.iter_causes().enumerate() {
+            for (i, cause) in error.chain().skip(1).enumerate() {
                 print!("{}", "  ".repeat(i + 1));
                 println!("Caused by: {}", cause);
             }
@@ -22,7 +22,7 @@ fn main() {
     }
 }
 
-fn print_capabilities_for_all_players() -> Result<(), Error> {
+fn print_capabilities_for_all_players() -> Result<()> {
     for player in PlayerFinder::new()
         .context("Failed to connect to D-Bus")?
         .find_all()
@@ -35,7 +35,7 @@ fn print_capabilities_for_all_players() -> Result<(), Error> {
     Ok(())
 }
 
-fn print_capabilities_for_player(player: Player<'_>) -> Result<(), Error> {
+fn print_capabilities_for_player(player: Player<'_>) -> Result<()> {
     println!(
         ">> Player: {} ({})",
         player.identity(),

--- a/examples/capabilities.rs
+++ b/examples/capabilities.rs
@@ -29,7 +29,7 @@ fn print_capabilities_for_all_players() -> Result<()> {
         .context("Could not fetch list of players")?
     {
         print_capabilities_for_player(player)?;
-        println!("");
+        println!();
     }
 
     Ok(())
@@ -42,7 +42,7 @@ fn print_capabilities_for_player(player: Player<'_>) -> Result<()> {
         player.unique_name()
     );
 
-    println!("");
+    println!();
     println!("\t─── MediaPlayer2 ───");
     print_value("CanQuit", player.can_quit());
     print_value("CanRaise", player.can_raise());
@@ -51,7 +51,7 @@ fn print_capabilities_for_player(player: Player<'_>) -> Result<()> {
     print_value("SupportedMimeTypes", player.get_supported_mime_types());
     print_value("SupportedUriSchemes", player.get_supported_uri_schemes());
 
-    println!("");
+    println!();
     println!("\t─── MediaPlayer2.Player ───");
     print_value("CanControl", player.can_control());
     print_value("CanGoNext", player.can_go_next());
@@ -71,7 +71,7 @@ fn print_capabilities_for_player(player: Player<'_>) -> Result<()> {
     print_value("MaximumRate", player.get_maximum_playback_rate());
     print_value("MinimumRate", player.get_minimum_playback_rate());
 
-    println!("");
+    println!();
     println!("\t─── MediaPlayer2.TrackList ───");
     if player.supports_track_lists() {
         print_value("CanEditTracks", player.can_edit_tracks());
@@ -131,7 +131,7 @@ where
     fn string_for_display(&self) -> Cow<'_, str> {
         let mut buf = String::new();
         for val in self {
-            if buf.len() == 0 {
+            if buf.is_empty() {
                 buf.push_str(&val.string_for_display());
             } else {
                 buf.push_str(&format!(

--- a/examples/control.rs
+++ b/examples/control.rs
@@ -1,6 +1,3 @@
-use mpris;
-use termion;
-
 use std::borrow::Cow;
 use std::io::{stdout, Stdout, Write};
 use std::time::Duration;
@@ -125,10 +122,7 @@ impl Action {
     }
 
     fn should_exit(&self) -> bool {
-        match *self {
-            Action::Quit => true,
-            _ => false,
-        }
+        matches!(self, Action::Quit)
     }
 }
 
@@ -208,7 +202,7 @@ impl<'a> App<'a> {
             print_instructions(&mut self.screen, self.player);
             print_playback_info(&mut self.screen, progress);
             if let Some(tracks) = track_list {
-                let next_track = find_next_track(current_track_id, tracks, &self.player);
+                let next_track = find_next_track(current_track_id, tracks, self.player);
                 print_track_list(&mut self.screen, tracks, next_track);
             }
             print_progress_bar(&mut self.screen, progress, supports_position);
@@ -388,8 +382,7 @@ fn find_next_track(
                 Some(id) => id != current_id,
                 None => false,
             })
-            .skip(1) // Skip one more to get the next one
-            .next()
+            .nth(1) // Skip one more to get the next one
     } else {
         None
     }
@@ -461,7 +454,7 @@ fn main() {
 
     let mut app = App {
         player: &player,
-        progress_tracker: progress_tracker,
+        progress_tracker,
         screen: AlternateScreen::from(stdout),
         stdin: termion::async_stdin(),
     };

--- a/examples/get_metadata.rs
+++ b/examples/get_metadata.rs
@@ -1,4 +1,4 @@
-use failure::{Error, ResultExt};
+use anyhow::{Context, Result};
 use mpris::PlayerFinder;
 
 fn main() {
@@ -6,7 +6,7 @@ fn main() {
         Ok(_) => {}
         Err(error) => {
             println!("Error: {}", error);
-            for (i, cause) in error.iter_causes().enumerate() {
+            for (i, cause) in error.chain().skip(1).enumerate() {
                 print!("{}", "  ".repeat(i + 1));
                 println!("Caused by: {}", cause);
             }
@@ -15,7 +15,7 @@ fn main() {
     }
 }
 
-fn print_metadata() -> Result<(), Error> {
+fn print_metadata() -> Result<()> {
     let player_finder = PlayerFinder::new().context("Could not connect to D-Bus")?;
 
     let player = player_finder

--- a/examples/show_tracklist.rs
+++ b/examples/show_tracklist.rs
@@ -1,4 +1,4 @@
-use failure::{Error, ResultExt};
+use anyhow::{Context, Result};
 use mpris::PlayerFinder;
 
 fn main() {
@@ -6,7 +6,7 @@ fn main() {
         Ok(_) => {}
         Err(error) => {
             println!("Error: {}", error);
-            for (i, cause) in error.iter_causes().enumerate() {
+            for (i, cause) in error.chain().skip(1).enumerate() {
                 print!("{}", "  ".repeat(i + 1));
                 println!("Caused by: {}", cause);
             }
@@ -15,7 +15,7 @@ fn main() {
     }
 }
 
-fn print_track_list() -> Result<(), Error> {
+fn print_track_list() -> Result<()> {
     let player_finder = PlayerFinder::new().context("Could not connect to D-Bus")?;
 
     let player = player_finder

--- a/examples/tracklist_control.rs
+++ b/examples/tracklist_control.rs
@@ -1,4 +1,4 @@
-use failure::{format_err, Error, ResultExt};
+use anyhow::{anyhow, Context, Error, Result};
 use mpris::{Player, PlayerFinder, TrackID};
 
 fn main() {
@@ -6,7 +6,7 @@ fn main() {
         Ok(_) => {}
         Err(error) => {
             println!("Error: {}", error);
-            for (i, cause) in error.iter_causes().enumerate() {
+            for (i, cause) in error.chain().skip(1).enumerate() {
                 print!("{}", "  ".repeat(i + 1));
                 println!("Caused by: {}", cause);
             }
@@ -15,7 +15,7 @@ fn main() {
     }
 }
 
-fn prompt_string(message: &str) -> Result<String, Error> {
+fn prompt_string(message: &str) -> Result<String> {
     use std::io::stdin;
     let mut answer = String::new();
 
@@ -25,7 +25,7 @@ fn prompt_string(message: &str) -> Result<String, Error> {
     Ok(String::from(answer.trim()))
 }
 
-fn run() -> Result<(), Error> {
+fn run() -> Result<()> {
     let player_finder = PlayerFinder::new().context("Could not connect to D-Bus")?;
 
     let player = player_finder
@@ -58,7 +58,7 @@ fn run() -> Result<(), Error> {
     Ok(())
 }
 
-fn print_track_list(player: &Player<'_>) -> Result<(), Error> {
+fn print_track_list(player: &Player<'_>) -> Result<()> {
     let track_list = player.get_track_list()?;
 
     println!("Track list:\n");
@@ -79,7 +79,7 @@ fn print_track_list(player: &Player<'_>) -> Result<(), Error> {
     Ok(())
 }
 
-fn select_track(player: &Player<'_>, lower_bound: usize) -> Result<Option<TrackID>, Error> {
+fn select_track(player: &Player<'_>, lower_bound: usize) -> Result<Option<TrackID>> {
     let track_list = player
         .get_track_list()
         .context("Could not get track list for player")?;
@@ -100,32 +100,28 @@ fn select_track(player: &Player<'_>, lower_bound: usize) -> Result<Option<TrackI
 
     let track_id = track_list
         .get(number - 1)
-        .ok_or_else(|| format_err!("Not a valid position"))?;
+        .ok_or_else(|| anyhow!("Not a valid position"))?;
 
     Ok(Some(track_id.clone()))
 }
 
-fn goto_track(player: &Player<'_>) -> Result<(), Error> {
+fn goto_track(player: &Player<'_>) -> Result<()> {
     match select_track(player, 1) {
         Ok(Some(track_id)) => player.go_to(&track_id).map_err(Error::from),
         Ok(None) => Ok(()),
-        Err(err) => Err(err)
-            .context("Failed to select track")
-            .map_err(Error::from),
+        Err(err) => Err(err.context("Failed to select track")),
     }
 }
 
-fn remove_track(player: &Player<'_>) -> Result<(), Error> {
+fn remove_track(player: &Player<'_>) -> Result<()> {
     match select_track(player, 1) {
         Ok(Some(track_id)) => player.remove_track(&track_id).map_err(Error::from),
         Ok(None) => Ok(()),
-        Err(err) => Err(err)
-            .context("Failed to select track")
-            .map_err(Error::from),
+        Err(err) => Err(err.context("Failed to select track")),
     }
 }
 
-fn add_track(player: &Player<'_>) -> Result<(), Error> {
+fn add_track(player: &Player<'_>) -> Result<()> {
     println!("NOTE: To add local media, start with the \"file://\" protocol. E.x. \"file:///path/to/file.mp3\"");
     let uri = prompt_string("Enter URI (or nothing to cancel) > ")?;
     if uri.is_empty() {

--- a/examples/tracklist_control.rs
+++ b/examples/tracklist_control.rs
@@ -63,7 +63,7 @@ fn print_track_list(player: &Player<'_>) -> Result<()> {
 
     println!("Track list:\n");
     let iter = track_list
-        .metadata_iter(&player)
+        .metadata_iter(player)
         .context("Could not load metadata for tracks")?;
 
     for (index, metadata) in iter.enumerate() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,7 +3,7 @@ use super::{
     TrackListError,
 };
 use crate::pooled_connection::MprisEvent;
-use failure::Fail;
+use thiserror::Error;
 
 /// Represents a change in [`Player`] state.
 ///
@@ -80,15 +80,15 @@ pub enum Event {
 }
 
 /// Errors that can occur while processing event streams.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum EventError {
     /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
-    #[fail(display = "D-Bus communication failed")]
-    DBusError(#[cause] DBusError),
+    #[error("D-Bus communication failed: {}", 0)]
+    DBusError(#[from] DBusError),
 
     /// Something went wrong with the track list. See the [`TrackListError`] type.
-    #[fail(display = "TrackList could not be refreshed")]
-    TrackListError(#[cause] TrackListError),
+    #[error("TrackList could not be refreshed: {}", 0)]
+    TrackListError(#[from] TrackListError),
 }
 
 /// Iterator that blocks forever until the player has an [`Event`].
@@ -286,17 +286,5 @@ impl<'a> Iterator for PlayerEvents<'a> {
 
         let event = self.buffer.remove(0);
         Some(Ok(event))
-    }
-}
-
-impl From<TrackListError> for EventError {
-    fn from(error: TrackListError) -> EventError {
-        EventError::TrackListError(error)
-    }
-}
-
-impl From<DBusError> for EventError {
-    fn from(error: DBusError) -> EventError {
-        EventError::DBusError(error)
     }
 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,4 +1,4 @@
-use failure::Fail;
+use thiserror::Error;
 
 use std::rc::Rc;
 
@@ -13,26 +13,20 @@ use crate::PlaybackStatus;
 const LIST_NAMES_TIMEOUT_MS: i32 = 500;
 
 /// This enum encodes possible error cases that could happen when finding players.
-#[derive(Fail, Debug)]
+#[derive(Debug, Error)]
 pub enum FindingError {
     /// No player was found matching the requirements of the calling method.
-    #[fail(display = "No player found")]
+    #[error("No player found")]
     NoPlayerFound,
 
     /// Finding failed due to an underlying [`DBusError`].
-    #[fail(display = "{}", _0)]
-    DBusError(#[cause] DBusError),
+    #[error("{}", 0)]
+    DBusError(#[from] DBusError),
 }
 
 impl From<dbus::Error> for FindingError {
     fn from(error: dbus::Error) -> Self {
         FindingError::DBusError(error.into())
-    }
-}
-
-impl From<DBusError> for FindingError {
-    fn from(error: DBusError) -> Self {
-        FindingError::DBusError(error)
     }
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,5 +1,5 @@
-use failure::Fail;
 use std::time::{Duration, Instant};
+use thiserror::Error;
 
 use super::{DBusError, LoopStatus, PlaybackStatus, TrackList, TrackListError};
 use crate::extensions::DurationExtensions;
@@ -80,15 +80,15 @@ pub struct ProgressTick<'a> {
 }
 
 /// Errors that can occur while refreshing progress.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ProgressError {
     /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
-    #[fail(display = "D-Bus communication failed")]
-    DBusError(#[cause] DBusError),
+    #[error("D-Bus communication failed: {}", 0)]
+    DBusError(#[from] DBusError),
 
     /// Something went wrong with the track list. See the [`TrackListError`] type.
-    #[fail(display = "TrackList could not be refreshed")]
-    TrackListError(#[cause] TrackListError),
+    #[error("TrackList could not be refreshed: {}", 0)]
+    TrackListError(#[from] TrackListError),
 }
 
 impl<'a> ProgressTracker<'a> {
@@ -423,18 +423,6 @@ impl Progress {
             _ => 0.0,
         };
         Duration::from_millis(elapsed_ms as u64)
-    }
-}
-
-impl From<TrackListError> for ProgressError {
-    fn from(error: TrackListError) -> ProgressError {
-        ProgressError::TrackListError(error)
-    }
-}
-
-impl From<DBusError> for ProgressError {
-    fn from(error: DBusError) -> ProgressError {
-        ProgressError::DBusError(error)
     }
 }
 

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -1,9 +1,9 @@
 use super::{DBusError, Metadata, Player};
-use failure::Fail;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::iter::{FromIterator, IntoIterator};
+use thiserror::Error;
 
 pub(crate) const NO_TRACK: &str = "/org/mpris/MediaPlayer2/TrackList/NoTrack";
 
@@ -49,16 +49,16 @@ pub struct TrackList {
 ///
 /// This is mostly [`DBusError`] with the extra possibility of borrow errors of the internal metadata
 /// cache.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum TrackListError {
     /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
-    #[fail(display = "D-Bus communication failed")]
-    DBusError(#[cause] DBusError),
+    #[error("D-Bus communication failed: {}", 0)]
+    DBusError(#[from] DBusError),
 
     /// Something went wrong with the borrowing logic for the internal cache. Perhaps you have
     /// multiple borrowed references to the cache live at the same time, for example because of
     /// multiple iterations?
-    #[fail(display = "Could not borrow cache: {}", _0)]
+    #[error("Could not borrow cache: {}", 0)]
     BorrowError(String),
 }
 
@@ -422,12 +422,6 @@ impl Iterator for MetadataIter {
             }
             None => None,
         }
-    }
-}
-
-impl From<DBusError> for TrackListError {
-    fn from(error: DBusError) -> TrackListError {
-        TrackListError::DBusError(error)
     }
 }
 


### PR DESCRIPTION
`failure` is [officially unmaintained](https://rustsec.org/advisories/RUSTSEC-2020-0036) which leads to `cargo audit` issuing a warning in projects using `mpris-rs`.

This PR uses:

- [`thiserror`](https://crates.io/crates/thiserror) for library `Error`s (implement the `std:error::Error` trait instead of `failure::Fail`).
- [`anyhow`](https://crates.io/crates/anyhow) for context identification in the examples.

Consequent to https://github.com/Mange/mpris-rs/pull/61#issuecomment-1013429316.