### PR TITLE
Player iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * `Player::has_playback_rate`, `Player::checked_get_playback_rate`,
     `Player::checked_set_playback_rate`
   * `Player::can_loop`, `Player::checked_get_loop_status`
+* `PlayerIter` that iterates over all of the players [Kanjirito][Kanjirito]
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Error on progress tracker for players that do not support shuffling. -
   [Stephan Henrichs (Kilobyte22)][Kilobyte22]
 * Events not added for streams - [Kanjirito][Kanjirito]
+* Incorrect error messages when using the `Display` trait [Kanjirito][Kanjirito]
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     `Player::checked_set_playback_rate`
   * `Player::can_loop`, `Player::checked_get_loop_status`
 * `PlayerIter` that iterates over all of the players [Kanjirito][Kanjirito]
+* `PlayerFinder.player_timeout_ms` field that changes the DBUS timeout value for
+  all new `Player`s [Kanjirito][Kanjirito]
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Thorne (harrisonthorne)][harrisonthorne]
 * Documentation was made easier to navigate - [Kanjirito][Kanjirito]
 * Use `thiserror` & `anyhow` instead of unmaintained `failure` - [fengalin][fengalin]
+* Removed `Player` lifetime [Kanjirito][Kanjirito]
 
 ## [v2.0.0-rc2] - 2020-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Documentation was made easier to navigate - [Kanjirito][Kanjirito]
 * Use `thiserror` & `anyhow` instead of unmaintained `failure` - [fengalin][fengalin]
 * Removed `Player` lifetime [Kanjirito][Kanjirito]
+* All `PlayerFinder` find methods switched to using `PlayerIter` [Kanjirito][Kanjirito]
 
 ## [v2.0.0-rc2] - 2020-02-15
 

--- a/examples/capabilities.rs
+++ b/examples/capabilities.rs
@@ -35,7 +35,7 @@ fn print_capabilities_for_all_players() -> Result<()> {
     Ok(())
 }
 
-fn print_capabilities_for_player(player: Player<'_>) -> Result<()> {
+fn print_capabilities_for_player(player: Player) -> Result<()> {
     println!(
         ">> Player: {} ({})",
         player.identity(),

--- a/examples/control.rs
+++ b/examples/control.rs
@@ -97,7 +97,7 @@ impl Action {
         }
     }
 
-    fn is_enabled(&self, player: &Player<'_>) -> bool {
+    fn is_enabled(&self, player: &Player) -> bool {
         match *self {
             Action::Quit => true,
             Action::PlayPause => player.can_pause().unwrap_or(false),
@@ -127,7 +127,7 @@ impl Action {
 }
 
 struct App<'a> {
-    player: &'a Player<'a>,
+    player: &'a Player,
     progress_tracker: ProgressTracker<'a>,
     stdin: termion::AsyncReader,
     screen: Screen,
@@ -219,7 +219,7 @@ impl<'a> App<'a> {
     }
 }
 
-fn print_instructions(screen: &mut Screen, player: &Player<'_>) {
+fn print_instructions(screen: &mut Screen, player: &Player) {
     let bold = termion::style::Bold;
     // Note: The NoBold variant enables double-underscore in Kitty terminal
     let nobold = termion::style::Reset;
@@ -270,11 +270,11 @@ fn control_player(result: Result<(), mpris::DBusError>) {
     result.expect("Could not control player");
 }
 
-fn toggle_shuffle(player: &Player<'_>) -> Result<(), mpris::DBusError> {
+fn toggle_shuffle(player: &Player) -> Result<(), mpris::DBusError> {
     player.set_shuffle(!player.get_shuffle()?)
 }
 
-fn cycle_loop_status(player: &Player<'_>) -> Result<(), mpris::DBusError> {
+fn cycle_loop_status(player: &Player) -> Result<(), mpris::DBusError> {
     let current_status = player.get_loop_status()?;
     let next_status = match current_status {
         LoopStatus::None => LoopStatus::Playlist,
@@ -284,7 +284,7 @@ fn cycle_loop_status(player: &Player<'_>) -> Result<(), mpris::DBusError> {
     player.set_loop_status(next_status)
 }
 
-fn change_volume(player: &Player<'_>, diff: f64) -> Result<(), mpris::DBusError> {
+fn change_volume(player: &Player, diff: f64) -> Result<(), mpris::DBusError> {
     let current_volume = player.get_volume()?;
     let new_volume = (current_volume + diff).max(0.0).min(1.0);
     player.set_volume(new_volume)
@@ -371,7 +371,7 @@ fn print_track_list(screen: &mut Screen, track_list: &TrackList, next_track: Opt
 fn find_next_track(
     current_track_id: Option<TrackID>,
     track_list: &TrackList,
-    player: &Player<'_>,
+    player: &Player,
 ) -> Option<Metadata> {
     if let Some(current_id) = current_track_id {
         track_list

--- a/examples/detecting_shutting_down.rs
+++ b/examples/detecting_shutting_down.rs
@@ -19,7 +19,7 @@ fn main() {
     let finder = PlayerFinder::new().expect("Could not connect to D-Bus");
     let mut lines_drawn = 0;
     let mut all_running = false;
-    let mut players: Vec<Player<'_>> = Vec::new();
+    let mut players: Vec<Player> = Vec::new();
 
     println!(
         "

--- a/examples/tracklist_control.rs
+++ b/examples/tracklist_control.rs
@@ -58,7 +58,7 @@ fn run() -> Result<()> {
     Ok(())
 }
 
-fn print_track_list(player: &Player<'_>) -> Result<()> {
+fn print_track_list(player: &Player) -> Result<()> {
     let track_list = player.get_track_list()?;
 
     println!("Track list:\n");
@@ -79,7 +79,7 @@ fn print_track_list(player: &Player<'_>) -> Result<()> {
     Ok(())
 }
 
-fn select_track(player: &Player<'_>, lower_bound: usize) -> Result<Option<TrackID>> {
+fn select_track(player: &Player, lower_bound: usize) -> Result<Option<TrackID>> {
     let track_list = player
         .get_track_list()
         .context("Could not get track list for player")?;
@@ -105,7 +105,7 @@ fn select_track(player: &Player<'_>, lower_bound: usize) -> Result<Option<TrackI
     Ok(Some(track_id.clone()))
 }
 
-fn goto_track(player: &Player<'_>) -> Result<()> {
+fn goto_track(player: &Player) -> Result<()> {
     match select_track(player, 1) {
         Ok(Some(track_id)) => player.go_to(&track_id).map_err(Error::from),
         Ok(None) => Ok(()),
@@ -113,7 +113,7 @@ fn goto_track(player: &Player<'_>) -> Result<()> {
     }
 }
 
-fn remove_track(player: &Player<'_>) -> Result<()> {
+fn remove_track(player: &Player) -> Result<()> {
     match select_track(player, 1) {
         Ok(Some(track_id)) => player.remove_track(&track_id).map_err(Error::from),
         Ok(None) => Ok(()),
@@ -121,7 +121,7 @@ fn remove_track(player: &Player<'_>) -> Result<()> {
     }
 }
 
-fn add_track(player: &Player<'_>) -> Result<()> {
+fn add_track(player: &Player) -> Result<()> {
     println!("NOTE: To add local media, start with the \"file://\" protocol. E.x. \"file:///path/to/file.mp3\"");
     let uri = prompt_string("Enter URI (or nothing to cancel) > ")?;
     if uri.is_empty() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -101,7 +101,7 @@ pub enum EventError {
 #[derive(Debug)]
 pub struct PlayerEvents<'a> {
     /// [`Player`] to watch.
-    player: &'a Player<'a>,
+    player: &'a Player,
 
     /// Queued up events found after the last signal.
     buffer: Vec<Event>,
@@ -113,8 +113,8 @@ pub struct PlayerEvents<'a> {
     track_list: Option<TrackList>,
 }
 
-impl<'a> PlayerEvents<'a> {
-    pub(crate) fn new(player: &'a Player<'a>) -> Result<PlayerEvents<'a>, DBusError> {
+impl PlayerEvents<'_> {
+    pub(crate) fn new(player: &Player) -> Result<PlayerEvents, DBusError> {
         let progress = Progress::from_player(player)?;
         Ok(PlayerEvents {
             player,

--- a/src/event.rs
+++ b/src/event.rs
@@ -83,11 +83,11 @@ pub enum Event {
 #[derive(Debug, Error)]
 pub enum EventError {
     /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
-    #[error("D-Bus communication failed: {}", 0)]
+    #[error("D-Bus communication failed: {0}")]
     DBusError(#[from] DBusError),
 
     /// Something went wrong with the track list. See the [`TrackListError`] type.
-    #[error("TrackList could not be refreshed: {}", 0)]
+    #[error("TrackList could not be refreshed: {0}")]
     TrackListError(#[from] TrackListError),
 }
 

--- a/src/find.rs
+++ b/src/find.rs
@@ -20,7 +20,7 @@ pub enum FindingError {
     NoPlayerFound,
 
     /// Finding failed due to an underlying [`DBusError`].
-    #[error("{}", 0)]
+    #[error("{0}")]
     DBusError(#[from] DBusError),
 }
 

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+use std::iter::FusedIterator;
 use std::rc::Rc;
 
 use dbus::ffidisp::{BusType, Connection};
@@ -211,4 +212,13 @@ impl Iterator for PlayerIter {
             DEFAULT_TIMEOUT_MS,
         ))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.buses.len();
+        (size, Some(size))
+    }
 }
+
+impl ExactSizeIterator for PlayerIter {}
+
+impl FusedIterator for PlayerIter {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # mpris
 //!
-//! `mpris` is an idiomatic library for dealing with MPRIS2-compatible media players over D-Bus.
+//! `mpris` is an idiomatic library for dealing with [MPRIS2][spec]-compatible media players over D-Bus.
 //!
 //! This would mostly apply to the Linux-ecosystem which is a heavy user of D-Bus.
 //!
@@ -25,6 +25,7 @@
 //! 1. Look at the examples under `examples/`.
 //! 2. Look at the [`PlayerFinder`] struct.
 //!
+//! [spec]: https://specifications.freedesktop.org/mpris-spec/latest/
 
 use thiserror::Error;
 
@@ -42,7 +43,7 @@ mod progress;
 mod track_list;
 
 pub use crate::event::{Event, EventError, PlayerEvents};
-pub use crate::find::{FindingError, PlayerFinder};
+pub use crate::find::{FindingError, PlayerFinder, PlayerIter};
 pub use crate::metadata::Metadata;
 pub use crate::metadata::Value as MetadataValue;
 pub use crate::metadata::ValueKind as MetadataValueKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,7 @@ pub enum LoopStatus {
 
 /// [`PlaybackStatus`] had an invalid string value.
 #[derive(Debug, Error)]
-#[error(
-    "PlaybackStatus must be one of Playing, Paused, Stopped, but was {}",
-    0
-)]
+#[error("PlaybackStatus must be one of Playing, Paused, Stopped, but was {0}")]
 pub struct InvalidPlaybackStatus(String);
 
 impl ::std::str::FromStr for PlaybackStatus {
@@ -109,7 +106,7 @@ impl ::std::str::FromStr for PlaybackStatus {
 
 /// [`LoopStatus`] had an invalid string value.
 #[derive(Debug, Error)]
-#[error("LoopStatus must be one of None, Track, Playlist, but was {}", 0)]
+#[error("LoopStatus must be one of None, Track, Playlist, but was {0}")]
 pub struct InvalidLoopStatus(String);
 
 impl ::std::str::FromStr for LoopStatus {
@@ -140,21 +137,21 @@ impl LoopStatus {
 #[derive(Debug, Error)]
 pub enum DBusError {
     /// An error occurred while talking to the D-Bus.
-    #[error("D-Bus call failed: {}", 0)]
+    #[error("D-Bus call failed: {0}")]
     TransportError(#[from] dbus::Error),
 
     /// Failed to parse an enum from a string value received from the [`Player`]. This means that the
     /// [`Player`] replied with unexpected data.
-    #[error("Failed to parse enum value: {}", 0)]
+    #[error("Failed to parse enum value: {0}")]
     EnumParseError(String),
 
     /// A D-Bus method call did not pass arguments of the correct type. This means that the [`Player`]
     /// replied with unexpected data.
-    #[error("D-Bus call failed: {}", 0)]
+    #[error("D-Bus call failed: {0}")]
     TypeMismatchError(#[from] dbus::arg::TypeMismatchError),
 
     /// Some other unexpected error occurred.
-    #[error("Unexpected error: {}", 0)]
+    #[error("Unexpected error: {0}")]
     Miscellaneous(String),
 }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -34,7 +34,7 @@ pub struct Progress {
 /// Call the [`tick`](Self::tick) method to get the most current [`Progress`] data.
 #[derive(Debug)]
 pub struct ProgressTracker<'a> {
-    player: &'a Player<'a>,
+    player: &'a Player,
     track_list: Option<TrackList>,
     interval: Duration,
     last_tick: Instant,
@@ -102,7 +102,7 @@ impl<'a> ProgressTracker<'a> {
     /// # Errors
     ///
     /// Returns an error in case Player metadata or state retrieval over DBus fails.
-    pub fn new(player: &'a Player<'a>, interval_ms: u32) -> Result<Self, DBusError> {
+    pub fn new(player: &'a Player, interval_ms: u32) -> Result<Self, DBusError> {
         Ok(ProgressTracker {
             player,
             interval: Duration::from_millis(u64::from(interval_ms)),
@@ -321,7 +321,7 @@ impl<'a> ProgressTracker<'a> {
 }
 
 impl Progress {
-    pub(crate) fn from_player<'a>(player: &'a Player<'a>) -> Result<Progress, DBusError> {
+    pub(crate) fn from_player(player: &Player) -> Result<Progress, DBusError> {
         Ok(Progress {
             metadata: player.get_metadata()?,
             playback_status: player.get_playback_status()?,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -83,11 +83,11 @@ pub struct ProgressTick<'a> {
 #[derive(Debug, Error)]
 pub enum ProgressError {
     /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
-    #[error("D-Bus communication failed: {}", 0)]
+    #[error("D-Bus communication failed: {0}")]
     DBusError(#[from] DBusError),
 
     /// Something went wrong with the track list. See the [`TrackListError`] type.
-    #[error("TrackList could not be refreshed: {}", 0)]
+    #[error("TrackList could not be refreshed: {0}")]
     TrackListError(#[from] TrackListError),
 }
 

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -52,13 +52,13 @@ pub struct TrackList {
 #[derive(Debug, Error)]
 pub enum TrackListError {
     /// Something went wrong with the D-Bus communication. See the [`DBusError`] type.
-    #[error("D-Bus communication failed: {}", 0)]
+    #[error("D-Bus communication failed: {0}")]
     DBusError(#[from] DBusError),
 
     /// Something went wrong with the borrowing logic for the internal cache. Perhaps you have
     /// multiple borrowed references to the cache live at the same time, for example because of
     /// multiple iterations?
-    #[error("Could not borrow cache: {}", 0)]
+    #[error("Could not borrow cache: {0}")]
     BorrowError(String),
 }
 

--- a/src/track_list.rs
+++ b/src/track_list.rs
@@ -293,7 +293,7 @@ impl TrackList {
     ///
     /// [`Metadata`] will be loaded from the provided player when not present in the metadata cache.
     /// If metadata loading fails, then a [`DBusError`] will be returned instead of the iterator.
-    pub fn metadata_iter(&self, player: &Player<'_>) -> Result<MetadataIter, TrackListError> {
+    pub fn metadata_iter(&self, player: &Player) -> Result<MetadataIter, TrackListError> {
         self.complete_cache(player)?;
         let metadata: HashMap<_, _> = self.metadata_cache.clone().into_inner();
         let ids = self.ids.clone();
@@ -310,7 +310,7 @@ impl TrackList {
     /// list.
     ///
     /// Cache for tracks that are no longer part of the player's tracklist will be removed.
-    pub fn reload(&mut self, player: &Player<'_>) -> Result<(), TrackListError> {
+    pub fn reload(&mut self, player: &Player) -> Result<(), TrackListError> {
         self.ids = player.get_track_list()?.ids;
         self.clear_extra_cache();
         Ok(())
@@ -320,7 +320,7 @@ impl TrackList {
     ///
     /// Cache will be replaced *after* the new metadata has been loaded, so on load errors the
     /// cache will still be maintained.
-    pub fn reload_cache(&self, player: &Player<'_>) -> Result<(), TrackListError> {
+    pub fn reload_cache(&self, player: &Player) -> Result<(), TrackListError> {
         let id_metadata = self
             .ids
             .iter()
@@ -337,7 +337,7 @@ impl TrackList {
     /// Fill in any holes in the cache so that each track on the list has a cached [`Metadata`] entry.
     ///
     /// If all tracks already have a cache entry, then this will do nothing.
-    pub fn complete_cache(&self, player: &Player<'_>) -> Result<(), TrackListError> {
+    pub fn complete_cache(&self, player: &Player) -> Result<(), TrackListError> {
         let ids: Vec<_> = self
             .ids_without_cache()
             .into_iter()


### PR DESCRIPTION
PR for changes mentioned in #64.

The 2 main things the PR includes are:

1. `Player` getting it's lifetime removed
2. The `PlayerIter` being added (and all of the find methods switched to using it)

The lifetime has been removed by getting rid of the `BusName` and `Path` structs in `Player`. `BusName` has been replaced with a regular `String` that's getting converted whenever needed and `Path` has been removed completely. The reason why I decided to just remove `Player.path` is that it's a constant `str` anyway and since this is a MPRIS library there is no reason to use a custom path that doesn't follow MPRIS specs. Direct quote from the [MPRIS2 spec](https://specifications.freedesktop.org/mpris-spec/latest/#Entry-point):
> The media player **must** expose the **/org/mpris/MediaPlayer2** object path

Also, removing the lifetime is a breaking change anyways and I highly doubt anyone was calling `Player::new` directly so I don't believe this will be a big problem. There is the option to add `Player.path` back and just make it a `String` but I don't see the benefit of that.

The `PlayerIter` is a simple struct that implements `Iterator` (and some other iterator traits). Internally it just iterates over the return value of `PlayerFinder::all_player_buses` and returns a `Result<Player, DBusError>` for each of the bus names. I decided to use `std::vec::IntoIter` directly instead of using he `Vec<String>` simply because it's:
 1. Easier (just call `next()`)
 2. "Probably very efficient since it's in the standard library"

The other way I would have done it is get the `Vec<String>`, reverse it and then do `self.buses.pop()` on each iteration. That way you avoid popping from the front and still keep the alphabetical order. I'm not completely sure if this was the right decision so let me know if you think there's a better way.


---

There are also some other smaller changes int he PR:
 1. Very slight documentation changes
 2. The error messages have been fixed. The formatting in the error macro was wrong and instead of printing the actual error message it was printing literally just `0`
 3. Added a player timeout field on `PlayerFinder`. This is a value that will be passed to every `Player` created from that finder. It basically lets you to set a new default `Player.timeout_ms` for found players.