### PR TITLE
Support single string value in `xesam:artist`

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -248,4 +248,30 @@ mod tests {
             assert_eq!(val, Value::I32(42));
         }
     }
+
+    #[test]
+    fn from_hashmap_artist_string() {
+        use std::iter::FromIterator;
+
+        let metadata = Metadata::from(HashMap::from_iter(
+            vec![(String::from("xesam:artist"), Value::from("Agnes Obel"))].into_iter(),
+        ));
+
+        assert_eq!(metadata.artists(), Some(vec!["Agnes Obel"]));
+    }
+
+    #[test]
+    fn from_hashmap_artists_list() {
+        use std::iter::FromIterator;
+
+        let metadata = Metadata::from(HashMap::from_iter(
+            vec![(
+                String::from("xesam:artist"),
+                Value::from(vec![Value::from("Agnes Obel")]),
+            )]
+            .into_iter(),
+        ));
+
+        assert_eq!(metadata.artists(), Some(vec!["Agnes Obel"]));
+    }
 }

--- a/src/metadata/value.rs
+++ b/src/metadata/value.rs
@@ -90,6 +90,7 @@ impl Value {
     pub fn as_str_array(&self) -> Option<Vec<&str>> {
         match *self {
             Value::Array(ref vec) => Some(vec.iter().flat_map(Value::as_str).collect()),
+            Value::String(ref string) => Some(vec![string.as_ref()]),
             _ => None,
         }
     }


### PR DESCRIPTION
[Telegram](https://github.com/telegramdesktop/tdesktop) incorrectly implements [mpris xesam:artist](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#xesam:artist) in that is supplies a single string value instead of a list of strings. But my kde setup is fine with this, i.e. my lock screen shows the correct now playing artist and kdeconnect shows correct artist on my android phone. Only [rescrobbled](https://github.com/InputUsername/rescrobbled) is confused by this (https://github.com/InputUsername/rescrobbled/issues/85) and sees no artist at all. This fixes it.