### PR TITLE
checked_get_track_list: fix fail on Spotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+* Add extra check for `Player::get_track_list()`. Without this,
+  `Player::track_progress()` would fail for Spotify. -
+  [Mihai Fufezan (fufexan)][fufexan]
 
 ## [v2.0.0] - 2022-11-15
 
@@ -218,3 +222,4 @@ versions.
 [harrisonthorne]: https://github.com/harrisonthorne
 [Kanjirito]: https://github.com/Kanjirito
 [fengalin]: https://github.com/fengalin
+[fufexan]: https://github.com/fufexan

--- a/src/player.rs
+++ b/src/player.rs
@@ -389,10 +389,10 @@ impl Player {
     /// **Note:** It's more expensive to rebuild this each time rather than trying to keep the same
     /// [`TrackList`] updated. See [`TrackList::reload`].
     ///
-    /// See [`get_track_list`](Self::get_track_list) and [`supports_track_lists`](Self::supports_track_lists)
-    /// if you want to manually handle compatibility checks.
+    /// See [`get_track_list`](Self::get_track_list), [`supports_track_lists`](Self::supports_track_lists) and
+    /// [`get_has_track_list`](Self::get_has_track_list) if you want to manually handle compatibility checks.
     pub fn checked_get_track_list(&self) -> Result<Option<TrackList>, DBusError> {
-        if self.supports_track_lists() {
+        if self.supports_track_lists() && self.get_has_track_list()? {
             self.get_track_list().map(Some)
         } else {
             Ok(None)


### PR DESCRIPTION
Fixes #70.
The cause of the issue was that Spotify reports that it supports tracklists, but doesn't actually send one through MPRIS. This change ensures we don't try to get the tracklist unless a player actually has one available.
