### PR TITLE
Fix feature = "cargo-clippy" deprecation

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -190,7 +190,7 @@ impl IntoIterator for Metadata {
 
 // Disable implicit_hasher; suggested code fix does not compile. I think this might be a false
 // positive, but I'm not sure.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::implicit_hasher))]
+#[allow(clippy::implicit_hasher)]
 impl From<Metadata> for HashMap<String, Value> {
     fn from(metadata: Metadata) -> Self {
         metadata.values


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html