### PR TITLE
enhance: Drop `from_variants` crate in favor of custom implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 dbus = "0.9.6"
 enum-kinds = "0.5.1"
-from_variants = "1.0.0"
 thiserror = "1.0.37"
 
 # For examples

--- a/src/metadata/value.rs
+++ b/src/metadata/value.rs
@@ -1,6 +1,5 @@
 use dbus::arg::ArgType;
 use enum_kinds::EnumKind;
-use from_variants::FromVariants;
 use std::collections::HashMap;
 
 /// Holds a dynamically-typed metadata value.

--- a/src/metadata/value.rs
+++ b/src/metadata/value.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 /// Holds a dynamically-typed metadata value.
 ///
 /// You will need to type-check this at runtime in order to use the value.
-#[derive(Debug, PartialEq, Clone, EnumKind, FromVariants)]
+#[derive(Debug, PartialEq, Clone, EnumKind)]
 #[enum_kind(ValueKind)]
 pub enum Value {
     /// Value is a string.
@@ -46,8 +46,34 @@ pub enum Value {
     Map(HashMap<String, Value>),
 
     /// Unsupported value type.
-    #[from_variants(skip)]
     Unsupported,
+}
+
+macro_rules! mk_value_from_impls {
+    ($($t:ty => $var:ident),* $(,)?) => {
+        $(
+            impl From<$t> for Value {
+                fn from(value: $t) -> Value {
+                    Value::$var(value)
+                }
+            }
+        )*
+    };
+}
+
+mk_value_from_impls! {
+    String => String,
+    i16 => I16,
+    i32 => I32,
+    i64 => I64,
+    u8 => U8,
+    u16 => U16,
+    u32 => U32,
+    u64 => U64,
+    f64 => F64,
+    bool => Bool,
+    Vec<Value> => Array,
+    HashMap<String, Value> => Map,
 }
 
 impl Value {


### PR DESCRIPTION
Fixes #87.

Removes the need for `from_variants` and its dependencies by using a simple `macro_rules!` to remove most of the code repetition.

```rust
macro_rules! mk_value_from_impls {
    ($($t:ty => $var:ident),* $(,)?) => {
        $(
            impl From<$t> for Value {
                fn from(value: $t) -> Value {
                    Value::$var(value)
                }
            }
        )*
    };
}

mk_value_from_impls! {
    String => String,
    i16 => I16,
    i32 => I32,
    i64 => I64,
    u8 => U8,
    u16 => U16,
    u32 => U32,
    u64 => U64,
    f64 => F64,
    bool => Bool,
    Vec<Value> => Array,
    HashMap<String, Value> => Map,
}
```